### PR TITLE
Don’t require apt lock to be available on build machine if there are no packages to install

### DIFF
--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -249,7 +249,7 @@ for package in $REQUIRED_PACKAGES ; do
   fi
 done
 
-# Ask if missing packages should get installed right now
+# If there are missing packages ask confirmation for install, or exit
 if [ -n "$MISSING_PACKAGES" ] ; then
   echo "the following packages needed by this script are not installed:"
   echo "$MISSING_PACKAGES"
@@ -257,10 +257,10 @@ if [ -n "$MISSING_PACKAGES" ] ; then
   echo -n "\ndo you want to install the missing packages right now? [y/n] "
   read confirm
   [ "$confirm" != "y" ] && exit 1
-fi
 
-# Make sure all required packages are installed
-apt-get -qq -y install ${REQUIRED_PACKAGES}
+  # Make sure all missing required packages are installed
+  apt-get -qq -y install ${MISSING_PACKAGES}
+fi
 
 # Check if ./bootstrap.d directory exists
 if [ ! -d "./bootstrap.d/" ] ; then


### PR DESCRIPTION
Currently the script always requires the apt lock to be free even if there are no packages to install on the build system. Although the script correctly detects missing packages, it still ends up calling :
   apt-get -qq -y install ${REQUIRED_PACKAGES}
in every case, even when all required packages are already installed.
This unfortunately makes the script fail when another apt operation is running, even when there’s no package missing for the build.

This patch relaxes the dependency on the apt lock, by only doing the apt… install when there are actual missing packages to install.