### PR TITLE
Apt-get in Chroot Environment Causes Script to Fail

### DIFF
--- a/bootstrap.d/10-bootstrap.sh
+++ b/bootstrap.d/10-bootstrap.sh
@@ -28,7 +28,7 @@ fi
 http_proxy=${APT_PROXY} debootstrap ${EXCLUDES} --arch="${RELEASE_ARCH}" --foreign ${VARIANT} --components="${COMPONENTS}" --include="${APT_INCLUDES}" "${RELEASE}" "${R}" "http://${APT_SERVER}/debian"
 
 # Copy qemu emulator binary to chroot
-install_exec "${QEMU_BINARY}" "${R}${QEMU_BINARY}"
+install -m 755 -o root -g root "${QEMU_BINARY}" "${R}${QEMU_BINARY}"
 
 # Copy debian-archive-keyring.pgp
 mkdir -p "${R}/usr/share/keyrings"


### PR DESCRIPTION
Since the release of Debian Stretch, the apt and apt-get commands run as the unprivileged user _apt.  With the permissions of the qemu-arm-static binary set to 644, the _apt user cannot execute commands and the script will fail when executing apt-get in the chroot environment.  

Relevant portions of the script output below:

```
+ chroot_exec apt-get -qq -y update
+ LANG=C LC_ALL=C DEBIAN_FRONTEND=noninteractive chroot /home/justin/rpi/rpi23-gen-image/images/stretch/build/chroot apt-get -qq -y update
W: GPG error: http://security.debian.org stretch/updates InRelease: Couldn't execute /usr/bin/apt-key to check /var/lib/apt/lists/partial/security.debian.org_dists_stretch_updates_InRelease
W: The repository 'http://security.debian.org stretch/updates InRelease' is not signed.
W: GPG error: http://ftp.debian.org/debian stretch-updates InRelease: Couldn't execute /usr/bin/apt-key to check /var/lib/apt/lists/partial/ftp.debian.org_debian_dists_stretch-updates_InRelease
W: The repository 'http://ftp.debian.org/debian stretch-updates InRelease' is not signed.
W: GPG error: http://ftp.debian.org/debian stretch Release: Couldn't execute /usr/bin/apt-key to check /var/lib/apt/lists/partial/ftp.debian.org_debian_dists_stretch_Release
W: The repository 'http://ftp.debian.org/debian stretch Release' is not signed.
+ chroot_exec apt-get -qq -y -u dist-upgrade
+ LANG=C LC_ALL=C DEBIAN_FRONTEND=noninteractive chroot /home/justin/rpi/rpi23-gen-image/images/stretch/build/chroot apt-get -qq -y -u dist-upgrade
WARNING: The following packages cannot be authenticated!
  libgnutls30
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
```
