### PR TITLE
Add missing option -allow-unauthenticated to apt-get to allow use of …

### DIFF
--- a/bootstrap.d/11-apt.sh
+++ b/bootstrap.d/11-apt.sh
@@ -38,7 +38,7 @@ fi
 
 # Upgrade package index and update all installed packages and changed dependencies
 chroot_exec apt-get -qq -y update
-chroot_exec apt-get -qq -y -u dist-upgrade
+chroot_exec apt-get -qq -y --allow-unauthenticated -u dist-upgrade
 
 if [ -d packages ] ; then
   for package in packages/*.deb ; do


### PR DESCRIPTION
…apporx mirror

Signed-off-by: Juergen Kosel <juergen.kosel@gmx.de>