### PR TITLE
Added new option APT_INCLUDES_LATE for installing packages using apt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ Set Debian packages server address. Choose a server from the list of Debian worl
 Set Proxy server address. Using a local Proxy-Cache like `apt-cacher-ng` will speed-up the bootstrapping process because all required Debian packages will only be downloaded from the Debian mirror site once.
 
 ##### `APT_INCLUDES`=""
-A comma separated list of additional packages to be installed during bootstrapping.
+A comma separated list of additional packages to be installed by debootstrap during bootstrapping.
+
+##### `APT_INCLUDES_LATE`=""
+A comma separated list of additional packages to be installed by apt after bootstrapping and after APT sources are set up.  This is useful for packages with pre-depends, which debootstrap do not handle well.
 
 ---
 

--- a/bootstrap.d/11-apt.sh
+++ b/bootstrap.d/11-apt.sh
@@ -40,6 +40,10 @@ fi
 chroot_exec apt-get -qq -y update
 chroot_exec apt-get -qq -y -u dist-upgrade
 
+if [ "$APT_INCLUDES_LATE" ] ; then
+  chroot_exec apt-get -qq -y install $(echo $APT_INCLUDES_LATE |tr , ' ')
+fi
+
 if [ -d packages ] ; then
   for package in packages/*.deb ; do
     cp $package ${R}/tmp


### PR DESCRIPTION
The option is useful for packages where debootstrap fail, for example packages with pre-dependencies.