### PR TITLE
Introduce as_nobody() function to make it easier to control how it is done.

### DIFF
--- a/bootstrap.d/13-kernel.sh
+++ b/bootstrap.d/13-kernel.sh
@@ -21,10 +21,10 @@ if [ "$BUILD_KERNEL" = true ] ; then
     fi
   else # KERNELSRC_DIR=""
     # Create temporary directory for kernel sources
-    temp_dir=$(sudo -u nobody mktemp -d)
+    temp_dir=$(as_nobody mktemp -d)
 
     # Fetch current RPi2/3 kernel sources
-    sudo -u nobody git -C "${temp_dir}" clone --depth=1 "${KERNEL_URL}"
+    as_nobody git -C "${temp_dir}" clone --depth=1 "${KERNEL_URL}"
 
     # Copy downloaded kernel sources
     mv "${temp_dir}/linux" "${R}/usr/src/"

--- a/bootstrap.d/15-rpi-config.sh
+++ b/bootstrap.d/15-rpi-config.sh
@@ -17,16 +17,16 @@ if [ "$BUILD_KERNEL" = true ] ; then
     cp ${RPI_FIRMWARE_DIR}/boot/start_x.elf ${BOOT_DIR}/start_x.elf
   else
     # Create temporary directory for boot binaries
-    temp_dir=$(sudo -u nobody mktemp -d)
+    temp_dir=$(as_nobody mktemp -d)
 
     # Install latest boot binaries from raspberry/firmware github
-    sudo -u nobody wget -q -O "${temp_dir}/bootcode.bin" "${FIRMWARE_URL}/bootcode.bin"
-    sudo -u nobody wget -q -O "${temp_dir}/fixup.dat" "${FIRMWARE_URL}/fixup.dat"
-    sudo -u nobody wget -q -O "${temp_dir}/fixup_cd.dat" "${FIRMWARE_URL}/fixup_cd.dat"
-    sudo -u nobody wget -q -O "${temp_dir}/fixup_x.dat" "${FIRMWARE_URL}/fixup_x.dat"
-    sudo -u nobody wget -q -O "${temp_dir}/start.elf" "${FIRMWARE_URL}/start.elf"
-    sudo -u nobody wget -q -O "${temp_dir}/start_cd.elf" "${FIRMWARE_URL}/start_cd.elf"
-    sudo -u nobody wget -q -O "${temp_dir}/start_x.elf" "${FIRMWARE_URL}/start_x.elf"
+    as_nobody wget -q -O "${temp_dir}/bootcode.bin" "${FIRMWARE_URL}/bootcode.bin"
+    as_nobody wget -q -O "${temp_dir}/fixup.dat" "${FIRMWARE_URL}/fixup.dat"
+    as_nobody wget -q -O "${temp_dir}/fixup_cd.dat" "${FIRMWARE_URL}/fixup_cd.dat"
+    as_nobody wget -q -O "${temp_dir}/fixup_x.dat" "${FIRMWARE_URL}/fixup_x.dat"
+    as_nobody wget -q -O "${temp_dir}/start.elf" "${FIRMWARE_URL}/start.elf"
+    as_nobody wget -q -O "${temp_dir}/start_cd.elf" "${FIRMWARE_URL}/start_cd.elf"
+    as_nobody wget -q -O "${temp_dir}/start_x.elf" "${FIRMWARE_URL}/start_x.elf"
 
     # Move downloaded boot binaries
     mv "${temp_dir}/"* "${BOOT_DIR}/"

--- a/bootstrap.d/20-networking.sh
+++ b/bootstrap.d/20-networking.sh
@@ -89,11 +89,11 @@ if [ "$ENABLE_WIRELESS" = true ] ; then
   fi
 
   # Create temporary directory for firmware binary blob
-  temp_dir=$(sudo -u nobody mktemp -d)
+  temp_dir=$(as_nobody mktemp -d)
 
   # Fetch firmware binary blob
-  sudo -u nobody wget -q -O "${temp_dir}/brcmfmac43430-sdio.bin" "${WLAN_FIRMWARE_URL}/brcmfmac43430-sdio.bin"
-  sudo -u nobody wget -q -O "${temp_dir}/brcmfmac43430-sdio.txt" "${WLAN_FIRMWARE_URL}/brcmfmac43430-sdio.txt"
+  as_nobody wget -q -O "${temp_dir}/brcmfmac43430-sdio.bin" "${WLAN_FIRMWARE_URL}/brcmfmac43430-sdio.bin"
+  as_nobody wget -q -O "${temp_dir}/brcmfmac43430-sdio.txt" "${WLAN_FIRMWARE_URL}/brcmfmac43430-sdio.txt"
 
   # Move downloaded firmware binary blob
   mv "${temp_dir}/brcmfmac43430-sdio."* "${WLAN_FIRMWARE_DIR}/"

--- a/bootstrap.d/41-uboot.sh
+++ b/bootstrap.d/41-uboot.sh
@@ -16,10 +16,10 @@ if [ "$ENABLE_UBOOT" = true ] ; then
     cp -r "${UBOOTSRC_DIR}" "${R}/tmp"
   else
     # Create temporary directory for U-Boot sources
-    temp_dir=$(sudo -u nobody mktemp -d)
+    temp_dir=$(as_nobody mktemp -d)
 
     # Fetch U-Boot sources
-    sudo -u nobody git -C "${temp_dir}" clone "${UBOOT_URL}"
+    as_nobody git -C "${temp_dir}" clone "${UBOOT_URL}"
 
     # Copy downloaded U-Boot sources
     mv "${temp_dir}/u-boot" "${R}/tmp/"

--- a/bootstrap.d/42-fbturbo.sh
+++ b/bootstrap.d/42-fbturbo.sh
@@ -15,10 +15,10 @@ if [ "$ENABLE_FBTURBO" = true ] ; then
     cp -r "${FBTURBOSRC_DIR}" "${R}/tmp"
   else
     # Create temporary directory for fbturbo sources
-    temp_dir=$(sudo -u nobody mktemp -d)
+    temp_dir=$(as_nobody mktemp -d)
 
     # Fetch fbturbo sources
-    sudo -u nobody git -C "${temp_dir}" clone "${FBTURBO_URL}"
+    as_nobody git -C "${temp_dir}" clone "${FBTURBO_URL}"
 
     # Move downloaded fbturbo sources
     mv "${temp_dir}/xf86-video-fbturbo" "${R}/tmp/"

--- a/functions.sh
+++ b/functions.sh
@@ -33,6 +33,11 @@ chroot_exec() {
   LANG=C LC_ALL=C DEBIAN_FRONTEND=noninteractive chroot ${R} $*
 }
 
+as_nobody() {
+  # Exec command as user nobody
+  sudo -u nobody LANG=C LC_ALL=C $*
+}
+
 install_readonly() {
   # Install file with user read-only permissions
   install -o root -g root -m 644 $*


### PR DESCRIPTION
This is useful when using libpam-tmpdir to replace the environment to avoid non-working paths in chroot.