### PR TITLE
Adding "deb-pkg" to kernel make command

### DIFF
--- a/bootstrap.d/13-kernel.sh
+++ b/bootstrap.d/13-kernel.sh
@@ -98,7 +98,7 @@ if [ "$BUILD_KERNEL" = true ] ; then
     fi
 
     # Cross compile kernel and modules
-    make -C "${KERNEL_DIR}" -j${KERNEL_THREADS} ARCH="${KERNEL_ARCH}" CROSS_COMPILE="${CROSS_COMPILE}" "${KERNEL_BIN_IMAGE}" modules dtbs
+    make -C "${KERNEL_DIR}" -j${KERNEL_THREADS} ARCH="${KERNEL_ARCH}" CROSS_COMPILE="${CROSS_COMPILE}" "${KERNEL_BIN_IMAGE}" modules dtbs deb-pkg
   fi
 
   # Check if kernel compilation was successful


### PR DESCRIPTION
This will produce packages in .deb format in "rpi23-gen-image/images/jessie/build/chroot/usr/src", which contains the kernel image. This will provide a more convenient way to update the kernel
on installed systems.

The kernel image in "linux-image-x.x.x_armhf.deb" works, however the headers in "linux-headers-x.x.x_armhf.deb" don't seem to work, though. DKMS throws:
`/bin/sh: 1: scripts/basic/fixdep: Exec format error`

I would guess it is related to the cross-compile of the kernel on the x86 host.

Fixes https://github.com/drtyhlpr/rpi23-gen-image/issues/76