### PR TITLE
set better defaults for arm64 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,16 +272,16 @@ This sets the cross compile enviornment for the compiler.
 This sets the kernel architecture for the compiler.
 
 ##### `KERNEL_IMAGE`="kernel7.img"
-Name of the image file in the boot partition.
+Name of the image file in the boot partition. If not set, `KERNEL_IMAGE` will be set to "kernel8.img" automatically if building for arm64.
 
 ##### `KERNEL_BRANCH`=""
 Name of the requested branch from the GIT location for the RPi Kernel. Default is using the current default branch from the GIT site.
 
 ##### `QEMU_BINARY`="/usr/bin/qemu-arm-static"
-Sets the QEMU enviornment for the Debian archive.
+Sets the QEMU enviornment for the Debian archive. If not set, `QEMU_BINARY` will be set to "/usr/bin/qemu-aarch64-static" automatically if building for arm64.
 
 ##### `KERNEL_DEFCONFIG`="bcm2709_defconfig"
-Sets the default config for kernel compiling.
+Sets the default config for kernel compiling. If not set, `KERNEL_DEFCONFIG` will be set to "bcmrpi3\_defconfig" automatically if building for arm64.
 
 ##### `KERNEL_REDUCE`=false
 Reduce the size of the generated kernel by removing unwanted device, network and filesystem drivers (experimental).

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -53,9 +53,18 @@ KERNEL_ARCH=${KERNEL_ARCH:=arm}
 RELEASE_ARCH=${RELEASE_ARCH:=armhf}
 CROSS_COMPILE=${CROSS_COMPILE:=arm-linux-gnueabihf-}
 COLLABORA_KERNEL=${COLLABORA_KERNEL:=3.18.0-trunk-rpi2}
-KERNEL_DEFCONFIG=${KERNEL_DEFCONFIG:=bcm2709_defconfig}
-KERNEL_IMAGE=${KERNEL_IMAGE:=kernel7.img}
-QEMU_BINARY=${QEMU_BINARY:=/usr/bin/qemu-arm-static}
+if [ "$KERNEL_ARCH" = "arm64" ] ; then
+  KERNEL_DEFCONFIG=${KERNEL_DEFCONFIG:=bcmrpi3_defconfig}
+  KERNEL_IMAGE=${KERNEL_IMAGE:=kernel8.img}
+else
+  KERNEL_DEFCONFIG=${KERNEL_DEFCONFIG:=bcm2709_defconfig}
+  KERNEL_IMAGE=${KERNEL_IMAGE:=kernel7.img}
+fi
+if [ "$RELEASE_ARCH" = "arm64" ] ; then
+  QEMU_BINARY=${QEMU_BINARY:=/usr/bin/qemu-aarch64-static}
+else
+  QEMU_BINARY=${QEMU_BINARY:=/usr/bin/qemu-arm-static}
+fi
 KERNEL_BRANCH=${KERNEL_BRANCH:=""}
 
 # URLs
@@ -166,7 +175,11 @@ KERNEL_THREADS=${KERNEL_THREADS:=1}
 KERNEL_HEADERS=${KERNEL_HEADERS:=true}
 KERNEL_MENUCONFIG=${KERNEL_MENUCONFIG:=false}
 KERNEL_REMOVESRC=${KERNEL_REMOVESRC:=true}
-KERNEL_BIN_IMAGE=${KERNEL_BIN_IMAGE:="zImage"}
+if [ "$KERNEL_ARCH" = "arm64" ] ; then
+  KERNEL_BIN_IMAGE=${KERNEL_BIN_IMAGE:="Image"}
+else
+  KERNEL_BIN_IMAGE=${KERNEL_BIN_IMAGE:="zImage"}
+fi
 
 # Kernel compilation from source directory settings
 KERNELSRC_DIR=${KERNELSRC_DIR:=""}


### PR DESCRIPTION
arm64-specific defaults are:
```
KERNEL_IMAGE=kernel8.img
KERNEL_BIN_IMAGE=Image
KERNEL_DEFCONFIG=bcmrpi3_defconfig
QEMU_BINARY=/usr/bin/qemu-aarch64-static
```