### PR TITLE
Proposed amendments  of 13-kernel.sh

### DIFF
--- a/bootstrap.d/13-kernel.sh
+++ b/bootstrap.d/13-kernel.sh
@@ -13,7 +13,7 @@ if [ "$BUILD_KERNEL" = true ] ; then
   # Copy existing kernel sources into chroot directory
   if [ -n "$KERNELSRC_DIR" ] && [ -d "$KERNELSRC_DIR" ] ; then
     # Copy kernel sources
-    cp -r "${KERNELSRC_DIR}/*" "${R}/usr/src/linux"
+    cp -r "${KERNELSRC_DIR}/"* "${R}/usr/src/linux"
 
     # Clean the kernel sources
     if [ "$KERNELSRC_CLEAN" = true ] && [ "$KERNELSRC_PREBUILT" = false ] ; then
@@ -25,13 +25,13 @@ if [ "$BUILD_KERNEL" = true ] ; then
 
     # Fetch current RPi2/3 kernel sources
     if [ -z "${KERNEL_BRANCH}" ] ; then
-      as_nobody -u nobody git -C "${temp_dir}" clone --depth=1 "${KERNEL_URL}" linux
+      as_nobody git -C "${temp_dir}" clone --depth=1 "${KERNEL_URL}" linux
     else
-      as_nobody -u nobody git -C "${temp_dir}" clone --depth=1 --branch "${KERNEL_BRANCH}" "${KERNEL_URL}" linux
-    fi
+      as_nobody git -C "${temp_dir}" clone --depth=1 --branch "${KERNEL_BRANCH}" "${KERNEL_URL}" linux
+   fi
     
     # Copy downloaded kernel sources
-    mv "${temp_dir}/linux/*" "${R}/usr/src/linux/"
+    cp -r "${temp_dir}/linux/"* "${R}/usr/src/linux/"
 
     # Remove temporary directory for kernel sources
     rm -fr "${temp_dir}"

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -212,8 +212,13 @@ CHROOT_SCRIPTS=${CHROOT_SCRIPTS:=""}
 
 # Packages required in the chroot build environment
 APT_INCLUDES=${APT_INCLUDES:=""}
-APT_INCLUDES="${APT_INCLUDES},apt-transport-https,apt-utils,ca-certificates,debian-archive-keyring,dialog,sudo,systemd,sysvinit-utils"
-
+# apt-transport-https has been removed from repositories
+# this induces qemu error 383 which does not prevent building an image
+if [ "$RELEASE" = "buster" ] ; then
+  APT_INCLUDES="${APT_INCLUDES},apt-utils,ca-certificates,debian-archive-keyring,dialog,sudo,systemd,sysvinit-utils"
+else
+  APT_INCLUDES="${APT_INCLUDES},apt-transport-https,apt-utils,ca-certificates,debian-archive-keyring,dialog,sudo,systemd,sysvinit-utils"
+fi
 # Packages required for bootstrapping
 REQUIRED_PACKAGES="debootstrap debian-archive-keyring qemu-user-static binfmt-support dosfstools rsync bmap-tools whois git bc psmisc dbus sudo"
 MISSING_PACKAGES=""

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -212,13 +212,14 @@ CHROOT_SCRIPTS=${CHROOT_SCRIPTS:=""}
 
 # Packages required in the chroot build environment
 APT_INCLUDES=${APT_INCLUDES:=""}
-# apt-transport-https has been removed from repositories
+APT_INCLUDES="${APT_INCLUDES},apt-transport-https,apt-utils,ca-certificates,debian-archive-keyring,dialog,sudo,systemd,sysvinit-utils"
+
+# Package apt-transport-https has been removed from Debian Buster release
 # this induces qemu error 383 which does not prevent building an image
 if [ "$RELEASE" = "buster" ] ; then
-  APT_INCLUDES="${APT_INCLUDES},apt-utils,ca-certificates,debian-archive-keyring,dialog,sudo,systemd,sysvinit-utils"
-else
-  APT_INCLUDES="${APT_INCLUDES},apt-transport-https,apt-utils,ca-certificates,debian-archive-keyring,dialog,sudo,systemd,sysvinit-utils"
+  APT_INCLUDES="$(echo ${APT_INCLUDES} | sed "s/apt-transport-https,/l/")"
 fi
+
 # Packages required for bootstrapping
 REQUIRED_PACKAGES="debootstrap debian-archive-keyring qemu-user-static binfmt-support dosfstools rsync bmap-tools whois git bc psmisc dbus sudo"
 MISSING_PACKAGES=""

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -217,7 +217,7 @@ APT_INCLUDES="${APT_INCLUDES},apt-transport-https,apt-utils,ca-certificates,debi
 # Package apt-transport-https has been removed from Debian Buster release
 # this induces qemu error 383 which does not prevent building an image
 if [ "$RELEASE" = "buster" ] ; then
-  APT_INCLUDES="$(echo ${APT_INCLUDES} | sed "s/apt-transport-https,/l/")"
+  APT_INCLUDES="$(echo ${APT_INCLUDES} | sed "s/apt-transport-https,//")"
 fi
 
 # Packages required for bootstrapping


### PR DESCRIPTION
First commit : 
 * Syntax error on the use of wildcard *  in the mv command
 * option -u used twice in git command

Second Commit (buster only) : 
 * removed apt-transport-https that has disappeared from repositories
This last change induces  errors with seccomp, (syscall 383 in 32 bit and syscall 277 in 64bit) 277 freezes the operations in apt script.
