### PR TITLE
Change every URL to https

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -151,10 +151,10 @@ CONFIG_TEMPLATE=rpi2stretch ./rpi23-gen-image.sh
 允许串行控制台接口. 没有连接显示器键盘的树莓派推荐打开, 此时如果网络无法连接至树莓派, 可以使用串行控制台连至系统. 
 
 ##### `ENABLE_I2C`=false
-允许树莓派2/3的 I2C 接口. 请对照 [树莓派2/3 引脚示意图](http://elinux.org/RPi_Low-level_peripherals) 正确连接 GPIO 引脚.
+允许树莓派2/3的 I2C 接口. 请对照 [树莓派2/3 引脚示意图](https://elinux.org/RPi_Low-level_peripherals) 正确连接 GPIO 引脚.
 
 ##### `ENABLE_SPI`=false
-允许树莓派2/3的 SPI 接口. 请对照 [树莓派2/3 引脚示意图](http://elinux.org/RPi_Low-level_peripherals) 正确连接 GPIO 引脚.
+允许树莓派2/3的 SPI 接口. 请对照 [树莓派2/3 引脚示意图](https://elinux.org/RPi_Low-level_peripherals) 正确连接 GPIO 引脚.
 
 ##### `ENABLE_IPV6`=true
 允许 IPv6 . 通过 systemd-networkd 配置管理网络接口.
@@ -199,10 +199,10 @@ CONFIG_TEMPLATE=rpi2stretch ./rpi23-gen-image.sh
 卸载包、删除文件以减小体积 详情查看 `REDUCE_*` 参数.
 
 ##### `ENABLE_UBOOT`=false
-使用 [U-Boot 引导器](http://git.denx.de/?p=u-boot.git;a=summary) 替代树莓派2/3 默认的第二阶段引导器(bootcode.bin).  U-Boot 可以通过网络使用 BOOTP/TFTP 协议引导镜像文件.
+使用 [U-Boot 引导器](https://git.denx.de/?p=u-boot.git;a=summary) 替代树莓派2/3 默认的第二阶段引导器(bootcode.bin).  U-Boot 可以通过网络使用 BOOTP/TFTP 协议引导镜像文件.
 
 ##### `UBOOTSRC_DIR`=""
-存放已下载 [U-Boot 引导器源文件](http://git.denx.de/?p=u-boot.git;a=summary) 的目录(`u-boot`).
+存放已下载 [U-Boot 引导器源文件](https://git.denx.de/?p=u-boot.git;a=summary) 的目录(`u-boot`).
 
 ##### `ENABLE_FBTURBO`=false
 安装并且允许 [硬件加速的 Xorg 显卡驱动](https://github.com/ssvb/xf86-video-fbturbo) `fbturbo`. 当前仅支持窗口的移动和滚动的硬件加速.
@@ -444,7 +444,7 @@ bmaptool copy ./images/jessie/2017-01-23-rpi3-jessie-root.img /dev/sdc
 * [Debian 交叉工具链 Wiki](https://wiki.debian.org/CrossToolchains)
 * [Github上的树莓派官方固件](https://github.com/raspberrypi/firmware)
 * [Github上的树莓派官方内核](https://github.com/raspberrypi/linux)
-* [U-BOOT git 仓库](http://git.denx.de/?p=u-boot.git;a=summary)
+* [U-BOOT git 仓库](https://git.denx.de/?p=u-boot.git;a=summary)
 * [Xorg DDX fbturbo驱动](https://github.com/ssvb/xf86-video-fbturbo)
 * [树莓派3无线接口固件](https://github.com/RPi-Distro/firmware-nonfree/tree/master/brcm80211/brcm)
 * [Collabora 树莓派2预编译内核](https://repositories.collabora.co.uk/debian/)

--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ Set the IP address for the second NTP server.
 Enable serial console interface. Recommended if no monitor or keyboard is connected to the RPi2/3. In case of problems fe. if the network (auto) configuration failed - the serial console can be used to access the system.
 
 ##### `ENABLE_I2C`=false
-Enable I2C interface on the RPi2/3. Please check the [RPi2/3 pinout diagrams](http://elinux.org/RPi_Low-level_peripherals) to connect the right GPIO pins.
+Enable I2C interface on the RPi2/3. Please check the [RPi2/3 pinout diagrams](https://elinux.org/RPi_Low-level_peripherals) to connect the right GPIO pins.
 
 ##### `ENABLE_SPI`=false
-Enable SPI interface on the RPi2/3. Please check the [RPi2/3 pinout diagrams](http://elinux.org/RPi_Low-level_peripherals) to connect the right GPIO pins.
+Enable SPI interface on the RPi2/3. Please check the [RPi2/3 pinout diagrams](https://elinux.org/RPi_Low-level_peripherals) to connect the right GPIO pins.
 
 ##### `ENABLE_IPV6`=true
 Enable IPv6 support. The network interface configuration is managed via systemd-networkd.
@@ -200,10 +200,10 @@ Use debootstrap script variant `minbase` which only includes essential packages 
 Reduce the disk space usage by deleting packages and files. See `REDUCE_*` parameters for detailed information.
 
 ##### `ENABLE_UBOOT`=false
-Replace the default RPi2/3 second stage bootloader (bootcode.bin) with [U-Boot bootloader](http://git.denx.de/?p=u-boot.git;a=summary). U-Boot can boot images via the network using the BOOTP/TFTP protocol.
+Replace the default RPi2/3 second stage bootloader (bootcode.bin) with [U-Boot bootloader](https://git.denx.de/?p=u-boot.git;a=summary). U-Boot can boot images via the network using the BOOTP/TFTP protocol.
 
 ##### `UBOOTSRC_DIR`=""
-Path to a directory (`u-boot`) of [U-Boot bootloader sources](http://git.denx.de/?p=u-boot.git;a=summary) that will be copied, configured, build and installed inside the chroot.
+Path to a directory (`u-boot`) of [U-Boot bootloader sources](https://git.denx.de/?p=u-boot.git;a=summary) that will be copied, configured, build and installed inside the chroot.
 
 ##### `ENABLE_FBTURBO`=false
 Install and enable the [hardware accelerated Xorg video driver](https://github.com/ssvb/xf86-video-fbturbo) `fbturbo`. Please note that this driver is currently limited to hardware accelerated window moving and scrolling.
@@ -452,7 +452,7 @@ The image files are provided by JRWR'S I/O PORT and are built once a Sunday at m
 * [Debian CrossToolchains Wiki](https://wiki.debian.org/CrossToolchains)
 * [Official Raspberry Pi Firmware on github](https://github.com/raspberrypi/firmware)
 * [Official Raspberry Pi Kernel on github](https://github.com/raspberrypi/linux)
-* [U-BOOT git repository](http://git.denx.de/?p=u-boot.git;a=summary)
+* [U-BOOT git repository](https://git.denx.de/?p=u-boot.git;a=summary)
 * [Xorg DDX driver fbturbo](https://github.com/ssvb/xf86-video-fbturbo)
 * [RPi3 Wireless interface firmware](https://github.com/RPi-Distro/firmware-nonfree/tree/master/brcm80211/brcm)
 * [Collabora RPi2 Kernel precompiled](https://repositories.collabora.co.uk/debian/)

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -73,7 +73,7 @@ FIRMWARE_URL=${FIRMWARE_URL:=https://github.com/raspberrypi/firmware/raw/master/
 WLAN_FIRMWARE_URL=${WLAN_FIRMWARE_URL:=https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm}
 COLLABORA_URL=${COLLABORA_URL:=https://repositories.collabora.co.uk/debian}
 FBTURBO_URL=${FBTURBO_URL:=https://github.com/ssvb/xf86-video-fbturbo.git}
-UBOOT_URL=${UBOOT_URL:=git://git.denx.de/u-boot.git}
+UBOOT_URL=${UBOOT_URL:=https://git.denx.de/u-boot.git}
 
 # Build directories
 BASEDIR=${BASEDIR:=$(pwd)/images/${RELEASE}}


### PR DESCRIPTION
This only leaves unencrypted/unverified:

- All Debian mirrors (no security problem, since apt verifies everything)
- The EmDebian repository in the README (nasty, since even the repository key is fetched over an untrusted connection)