### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Install and enable OpenSSH service. The default configuration of the service doe
 Allow the installation of non-free Debian packages that do not comply with the DFSG. This is required to install closed-source firmware binary blobs.
 
 ##### `ENABLE_WIRELESS`=false
-Download and install the [closed-source firmware binary blob](https://github.com/RPi-Distro/firmware-nonfree/tree/master/brcm80211/brcm) that is required to run the internal wireless interface of the Raspberry Pi model `3`. This parameter is ignored if the specified `RPI_MODEL` is not `3`.
+Download and install the [closed-source firmware binary blob](https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm) that is required to run the internal wireless interface of the Raspberry Pi model `3`. This parameter is ignored if the specified `RPI_MODEL` is not `3`.
 
 ##### `ENABLE_RSYSLOG`=true
 If set to false, disable and uninstall rsyslog (so logs will be available only

--- a/bootstrap.d/12-locale.sh
+++ b/bootstrap.d/12-locale.sh
@@ -28,10 +28,10 @@ if [ $(echo "$APT_INCLUDES" | grep ",locales") ] ; then
   chroot_exec update-locale LANG="${DEFLOCAL}"
 
   # Install and setup default keyboard configuration
-  if [ "$XKB_MODEL" != "" ] ; then
+  if [ "$XKB_MODEL" != "pc105" ] ; then
     sed -i "s/^XKBMODEL.*/XKBMODEL=\"${XKB_MODEL}\"/" "${ETC_DIR}/default/keyboard"
   fi
-  if [ "$XKB_LAYOUT" != "" ] ; then
+  if [ "$XKB_LAYOUT" != "us" ] ; then
     sed -i "s/^XKBLAYOUT.*/XKBLAYOUT=\"${XKB_LAYOUT}\"/" "${ETC_DIR}/default/keyboard"
   fi
   if [ "$XKB_VARIANT" != "" ] ; then

--- a/bootstrap.d/15-rpi-config.sh
+++ b/bootstrap.d/15-rpi-config.sh
@@ -95,7 +95,7 @@ if [ "$ENABLE_INITRAMFS" = true ] ; then
 fi
 
 # Disable RPi3 Bluetooth and restore ttyAMA0 serial device
-if [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ]; then
+if [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
   if [ "$ENABLE_CONSOLE" = true ] && [ "$ENABLE_UBOOT" = false ] ; then
     echo "dtoverlay=pi3-disable-bt" >> "${BOOT_DIR}/config.txt"
     echo "enable_uart=1" >> "${BOOT_DIR}/config.txt"

--- a/bootstrap.d/20-networking.sh
+++ b/bootstrap.d/20-networking.sh
@@ -127,7 +127,7 @@ if [ "$ENABLE_WIRELESS" = true ] ; then
   if [ "$RPI_MODEL" = 3P ] ; then
   chown root:root "${WLAN_FIRMWARE_DIR}/brcmfmac43455-sdio."*
   chmod 600 "${WLAN_FIRMWARE_DIR}/brcmfmac43455-sdio."*  
-  else
+  elif [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 0 ] ; then
   chown root:root "${WLAN_FIRMWARE_DIR}/brcmfmac43430-sdio."*
   chmod 600 "${WLAN_FIRMWARE_DIR}/brcmfmac43430-sdio."*
   fi

--- a/bootstrap.d/20-networking.sh
+++ b/bootstrap.d/20-networking.sh
@@ -107,7 +107,7 @@ if [ "$ENABLE_WIRELESS" = true ] ; then
   as_nobody wget -q -O "${temp_dir}/brcmfmac43455-sdio.bin" "${WLAN_FIRMWARE_URL}/brcmfmac43455-sdio.bin"
   as_nobody wget -q -O "${temp_dir}/brcmfmac43455-sdio.txt" "${WLAN_FIRMWARE_URL}/brcmfmac43455-sdio.txt"
   as_nobody wget -q -O "${temp_dir}/brcmfmac43455-sdio.clm_blob" "${WLAN_FIRMWARE_URL}/brcmfmac43455-sdio.clm_blob"
-  else
+  elif [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 0 ] ; then
   # Fetch firmware binary blob for RPI3
   as_nobody wget -q -O "${temp_dir}/brcmfmac43430-sdio.bin" "${WLAN_FIRMWARE_URL}/brcmfmac43430-sdio.bin"
   as_nobody wget -q -O "${temp_dir}/brcmfmac43430-sdio.txt" "${WLAN_FIRMWARE_URL}/brcmfmac43430-sdio.txt"
@@ -116,7 +116,7 @@ if [ "$ENABLE_WIRELESS" = true ] ; then
   # Move downloaded firmware binary blob
   if [ "$RPI_MODEL" = 3P ] ; then
   mv "${temp_dir}/brcmfmac43455-sdio."* "${WLAN_FIRMWARE_DIR}/"
-  else
+  elif [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 0 ] ; then
   mv "${temp_dir}/brcmfmac43430-sdio."* "${WLAN_FIRMWARE_DIR}/"
   fi
   

--- a/bootstrap.d/21-firewall.sh
+++ b/bootstrap.d/21-firewall.sh
@@ -10,9 +10,9 @@ if [ "$ENABLE_IPTABLES" = true ] ; then
   mkdir -p "${ETC_DIR}/iptables"
   
   # make sure iptables-legacy,iptables-legacy-restore and iptables-legacy-save are the used alternatives
-  chroot_exec update-alternatives --verbose --set iptables /usr/bin/iptables-legacy
-  chroot_exec update-alternatives --verbose --set iptables-save /usr/bin/iptables-legacy-save
-  chroot_exec update-alternatives --verbose --set iptables-restore /usr/bin/iptables-legacy-restore
+  chroot_exec update-alternatives --verbose --set iptables /usr/sbin/iptables-legacy
+  chroot_exec update-alternatives --verbose --set iptables-save /usr/sbin/iptables-legacy-save
+  chroot_exec update-alternatives --verbose --set iptables-restore /usr/sbin/iptables-legacy-restore
   
   # Install iptables systemd service
   install_readonly files/iptables/iptables.service "${ETC_DIR}/systemd/system/iptables.service"

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -306,9 +306,9 @@ if [ "$BUILD_KERNEL" = true ] ; then
     if [ "$RELEASE_ARCH" = "armhf" ]; then
       REQUIRED_PACKAGES="${REQUIRED_PACKAGES} crossbuild-essential-armhf"
     fi
-    if [ "$RELEASE_ARCH" = "arm64" ]; then
-      REQUIRED_PACKAGES="${REQUIRED_PACKAGES} crossbuild-essential-arm64"
-    fi
+  fi
+  if [ "$RELEASE_ARCH" = "arm64" ]; then
+    REQUIRED_PACKAGES="${REQUIRED_PACKAGES} crossbuild-essential-arm64"
   fi
 fi
 

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -464,7 +464,7 @@ fi
 
 # Add iptables IPv4/IPv6 package
 if [ "$ENABLE_IPTABLES" = true ] ; then
-  APT_INCLUDES="${APT_INCLUDES},iptables"
+  APT_INCLUDES="${APT_INCLUDES},iptables,iptables-persistent"
 fi
 
 # Add openssh server package

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -448,7 +448,7 @@ if [ "$ENABLE_MINBASE" = true ] ; then
 fi
 
 # Add required locales packages
-if [ "$DEFLOCAL" != "en_US.UTF-8" ] ; then
+if [ "$DEFLOCAL" != "en_US.UTF-8" ] || ([ -n XKB_MODEL ] || [ -n XKB_LAYOUT ] ||  [ -n XKB_VARIANT ] ||  [ -n XKB_OPTIONS ]); then
   APT_INCLUDES="${APT_INCLUDES},locales,keyboard-configuration,console-setup"
 fi
 


### PR DESCRIPTION
- iptables path fix
- crosscompiler check fix
-fix #73 
-fix RPI0 not including WIFI Firmware for MODEL=0W
- firmware blob link in readme fix
- iptables need iptables-persistent package to provide 

due to the fact i made soo many errors, i'll compile every PR i do...

**BTW**:  I would suggest using kernel version 4.14 as default atm. Latest rpi-firmware [commits](https://github.com/raspberrypi/firmware/commit/55e591283f456ab9cebd9c31aaef4939f814880d) are for this version and kernel 4.18 has issues with [bpf_syscall](https://github.com/drtyhlpr/rpi23-gen-image/issues/145#issuecomment-437345422)