### PR TITLE
Refactor mergeable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ A comma separated list of additional packages to be installed by apt after boots
 ---
 
 #### General system settings:
+##### `SET_ARCH`=32
+Set Architecture to default 32bit. If you want to to compile 64bit (RPI3 or RPI3+) set it to `64`. This Option will set every needed crosscompiler or boeard specific option for a successful build.
+If you want to change e.g. cross-compiler -> Templates alwys override defaults
+
 ##### `RPI_MODEL`=2
 Specifiy the target Raspberry Pi hardware model. The script at this time supports the following Raspberry Pi models:
 `0`  = Used for Raspberry Pi 0 and Raspberry Pi 0 W

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rpi23-gen-image
 ## Introduction
-`rpi23-gen-image.sh` is an advanced Debian Linux bootstrapping shell script for generating Debian OS images for Raspberry Pi 2 (RPi2) and Raspberry Pi 3 (RPi3) computers. The script at this time supports the bootstrapping of the Debian (armhf) releases `jessie`, `stretch` and `buster`. Raspberry Pi 3 images are generated for 32-bit mode only. Raspberry Pi 3 64-bit images can be generated using custom configuration parameters (```templates/rpi3-stretch-arm64-4.11.y```).
+`rpi23-gen-image.sh` is an advanced Debian Linux bootstrapping shell script for generating Debian OS images for Raspberry Pi 2 (RPi2) and Raspberry Pi 3 (RPi3) computers. The script at this time supports the bootstrapping of the Debian (armhf) releases `stretch` and `buster`. Raspberry Pi 3 images are generated for 32-bit mode only. Raspberry Pi 3 64-bit images can be generated using custom configuration parameters (```templates/rpi3-stretch-arm64-4.11.y```).
 
 ## Build dependencies
 The following list of Debian packages must be installed on the build system because they are essentially required for the bootstrapping process. The script will check if all required packages are installed and missing packages will be installed automatically if confirmed by the user.
@@ -9,16 +9,7 @@ The following list of Debian packages must be installed on the build system beca
 
 It is recommended to configure the `rpi23-gen-image.sh` script to build and install the latest Raspberry Pi Linux kernel. For the RPi3 this is mandatory. Kernel compilation and linking will be performed on the build system using an ARM (armhf) cross-compiler toolchain.
 
-The script has been tested using the default `crossbuild-essential-armhf` toolchain meta package on Debian Linux `jessie` and `stretch` build systems. Please check the [Debian CrossToolchains Wiki](https://wiki.debian.org/CrossToolchains) for further information.
-
-If a Debian Linux `jessie` build system is used it will be required to add the [Debian Cross-toolchains repository](http://emdebian.org/tools/debian/) first:
-
-```
-echo "deb http://emdebian.org/tools/debian/ jessie main" > /etc/apt/sources.list.d/crosstools.list
-sudo -u nobody wget -O - http://emdebian.org/tools/debian/emdebian-toolchain-archive.key | apt-key add -
-dpkg --add-architecture armhf
-apt-get update
-```
+The script has been tested using the default `crossbuild-essential-armhf` toolchain meta package on Debian Linux and `stretch` build systems. Please check the [Debian CrossToolchains Wiki](https://wiki.debian.org/CrossToolchains) for further information.
 
 ## Command-line parameters
 The script accepts certain command-line parameters to enable or disable specific OS features, services and configuration settings. These parameters are passed to the `rpi23-gen-image.sh` script via (simple) shell-variables. Unlike environment shell-variables (simple) shell-variables are defined at the beginning of the command-line call of the `rpi23-gen-image.sh` script.
@@ -55,7 +46,7 @@ CONFIG_TEMPLATE=rpi2stretch ./rpi23-gen-image.sh
 Set Debian packages server address. Choose a server from the list of Debian worldwide [mirror sites](https://www.debian.org/mirror/list). Using a nearby server will probably speed-up all required downloads within the bootstrapping process.
 
 ##### `APT_PROXY`=""
-Set Proxy server address. Using a local Proxy-Cache like `apt-cacher-ng` will speed-up the bootstrapping process because all required Debian packages will only be downloaded from the Debian mirror site once.
+Set Proxy server address. Using a local Proxy-Cache like `apt-cacher-ng` will speed-up the bootstrapping process because all required Debian packages will only be downloaded from the Debian mirror site once. If `apt-cacher-ng` is running on default `http://127.0.0.1:3142` it is autodetected and you don't need to set this.
 
 ##### `APT_INCLUDES`=""
 A comma separated list of additional packages to be installed by debootstrap during bootstrapping.
@@ -76,8 +67,8 @@ Specifiy the target Raspberry Pi hardware model. The script at this time support
 `3P` = Used for Pi 3 model B+
 `BUILD_KERNEL`=true will automatically be set if the Raspberry Pi model `3` or `3P` is used.
 
-##### `RELEASE`="jessie"
-Set the desired Debian release name. The script at this time supports the bootstrapping of the Debian releases "jessie", "stretch" and "buster". `BUILD_KERNEL`=true will automatically be set if the Debian releases `stretch` or `buster` are used.
+##### `RELEASE`="buster"
+Set the desired Debian release name. The script at this time supports the bootstrapping of the Debian releases "stretch" and "buster". `BUILD_KERNEL`=true will automatically be set if the Debian releases `stretch` or `buster` are used.
 
 ##### `RELEASE_ARCH`="armhf"
 Set the desired Debian release architecture.

--- a/bootstrap.d/10-bootstrap.sh
+++ b/bootstrap.d/10-bootstrap.sh
@@ -19,7 +19,7 @@ if [ "$ENABLE_MINBASE" = true ] ; then
 fi
 
 # Base debootstrap (unpack only)
-http_proxy=${APT_PROXY} debootstrap "${APT_EXCLUDES}" --arch="${RELEASE_ARCH}" --foreign ${VARIANT} --components="${COMPONENTS}" --include="${APT_INCLUDES}" "${RELEASE}" "${R}" "http://${APT_SERVER}/debian"
+http_proxy=${APT_PROXY} debootstrap ${APT_EXCLUDES} --arch="${RELEASE_ARCH}" --foreign ${VARIANT} --components="${COMPONENTS}" --include="${APT_INCLUDES}" "${RELEASE}" "${R}" "http://${APT_SERVER}/debian"
 
 # Copy qemu emulator binary to chroot
 install -m 755 -o root -g root "${QEMU_BINARY}" "${R}${QEMU_BINARY}"

--- a/bootstrap.d/11-apt.sh
+++ b/bootstrap.d/11-apt.sh
@@ -12,28 +12,12 @@ if [ -z "$APT_PROXY" ] ; then
 fi
 
 if [ "$BUILD_KERNEL" = false ] ; then
-  # Install APT pinning configuration for flash-kernel package
-  install_readonly files/apt/flash-kernel "${ETC_DIR}/apt/preferences.d/flash-kernel"
-
-  # Install APT sources.list
-  install_readonly files/apt/sources.list "${ETC_DIR}/apt/sources.list"
-  echo "deb ${COLLABORA_URL} ${RELEASE} rpi2" >> "${ETC_DIR}/apt/sources.list"
-
-  # Upgrade collabora package index and install collabora keyring
-  chroot_exec apt-get -qq -y update
-  chroot_exec apt-get -qq -y --allow-unauthenticated install collabora-obs-archive-keyring
-else # BUILD_KERNEL=true
-  # Install APT sources.list
-  install_readonly files/apt/sources.list "${ETC_DIR}/apt/sources.list"
-
-  # Use specified APT server and release
-  sed -i "s/\/ftp.debian.org\//\/${APT_SERVER}\//" "${ETC_DIR}/apt/sources.list"
-  sed -i "s/ jessie/ ${RELEASE}/" "${ETC_DIR}/apt/sources.list"
-fi
-
-# Allow the installation of non-free Debian packages
-if [ "$ENABLE_NONFREE" = true ] ; then
-  sed -i "s/ contrib/ contrib non-free/" "${ETC_DIR}/apt/sources.list"
+  echo "Downloading precompiled kernel"
+  echo "error: not configured"
+  exit 1;
+# BUILD_KERNEL=true
+else
+  echo "No precompiled kernel repositories were added"
 fi
 
 # Upgrade package index and update all installed packages and changed dependencies

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -247,7 +247,7 @@ CHROOT_SCRIPTS=${CHROOT_SCRIPTS:=""}
 
 # Packages required in the chroot build environment
 APT_INCLUDES=${APT_INCLUDES:=""}
-APT_INCLUDES="${APT_INCLUDES},apt-transport-https,apt-utils,ca-certificates,debian-archive-keyring,dialog,sudo,systemd,sysvinit-utils"
+APT_INCLUDES="${APT_INCLUDES},apt-transport-https,apt-utils,ca-certificates,debian-archive-keyring,dialog,sudo,systemd,sysvinit-utils,locales,keyboard-configuration,console-setup"
 
 #Packages to exclude from chroot build environment
 APT_EXCLUDES=${APT_EXCLUDES:=""}
@@ -265,6 +265,10 @@ set +x
 if [ "$ENABLE_SYSVINIT" = false ] ; then
 APT_EXCLUDES="--exclude=${APT_EXCLUDES},init,systemd-sysv"
 fi
+
+#Check if apt-cacher-ng has its default port open on and set APT_PROXY
+if [ -n "$(lsof -i :3142)" ] ; then
+HTTP_PROXY=http://127.0.0.1:3142/
 
 # Set Raspberry Pi model specific configuration
 if [ "$RPI_MODEL" = 0 ] ; then
@@ -358,7 +362,7 @@ fi
 
 # Add device-tree-compiler required for building the U-Boot bootloader
 if [ "$ENABLE_UBOOT" = true ] ; then
-  APT_INCLUDES="${APT_INCLUDES},device-tree-compiler,bison,flex"
+  APT_INCLUDES="${APT_INCLUDES},device-tree-compiler,bison,flex,bc"
 fi
 
 # Check if root SSH (v2) public key file exists
@@ -468,11 +472,6 @@ trap cleanup 0 1 2 3 6
 # Add required packages for the minbase installation
 if [ "$ENABLE_MINBASE" = true ] ; then
   APT_INCLUDES="${APT_INCLUDES},vim-tiny,netbase,net-tools,ifupdown"
-fi
-
-# Add required locales packages
-if [ "$DEFLOCAL" != "en_US.UTF-8" ] || ([ -n XKB_MODEL ] || [ -n XKB_LAYOUT ] ||  [ -n XKB_VARIANT ] ||  [ -n XKB_OPTIONS ]); then
-  APT_INCLUDES="${APT_INCLUDES},locales,keyboard-configuration,console-setup"
 fi
 
 # Add parted package, required to get partprobe utility


### PR DESCRIPTION
Hi this "refactor" kicks out old jessie support and old version3 kernel packages from collabora.
- some cleanup on old vars is needed
- build kernel by default
- set buster as default
- "autodetect" apt_cacher-ng
- I will include precompiled pi3 kernel from [sakaki](https://github.com/sakaki-/bcmrpi3-kernel-bis) in next pull
- many bugs in the past because of locales - atm the check is always true => so remove it and include locals,keyboard and console setup as default