### PR TITLE
Use 4.14.y as default kernel version

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -1,5 +1,5 @@
 ## 介绍
-`rpi23-gen-image.sh` 是一个自动生成树莓派2/3系统镜像的脚本工具, 当前支持自动生成32位 armhf 架构的Debian, 发行版本`jessie`, `stretch` 和 `buster`. 树莓派3 64位镜像需要使用特定的配置参数 (```templates/rpi3-stretch-arm64-4.11.y```). 
+`rpi23-gen-image.sh` 是一个自动生成树莓派2/3系统镜像的脚本工具, 当前支持自动生成32位 armhf 架构的Debian, 发行版本`jessie`, `stretch` 和 `buster`. 树莓派3 64位镜像需要使用特定的配置参数 (```templates/rpi3-stretch-arm64-4.14.y```). 
 
 ## 构建环境所依赖的包
 一定要安装好下列deb包, 他们是构建过程需要的核心包. 脚本会自动检查, 如果缺少,经用户确认后会自动安装. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rpi23-gen-image
 ## Introduction
-`rpi23-gen-image.sh` is an advanced Debian Linux bootstrapping shell script for generating Debian OS images for Raspberry Pi 2 (RPi2) and Raspberry Pi 3 (RPi3) computers. The script at this time supports the bootstrapping of the Debian (armhf) releases `stretch` and `buster`. Raspberry Pi 3 images are generated for 32-bit mode only. Raspberry Pi 3 64-bit images can be generated using custom configuration parameters (```templates/rpi3-stretch-arm64-4.11.y```).
+`rpi23-gen-image.sh` is an advanced Debian Linux bootstrapping shell script for generating Debian OS images for Raspberry Pi 2 (RPi2) and Raspberry Pi 3 (RPi3) computers. The script at this time supports the bootstrapping of the Debian (armhf) releases `stretch` and `buster`. Raspberry Pi 3 images are generated for 32-bit mode only. Raspberry Pi 3 64-bit images can be generated using custom configuration parameters (```templates/rpi3-stretch-arm64-4.14.y```).
 
 ## Build dependencies
 The following list of Debian packages must be installed on the build system because they are essentially required for the bootstrapping process. The script will check if all required packages are installed and missing packages will be installed automatically if confirmed by the user.

--- a/templates/rpi3-stretch-arm64-4.14.y
+++ b/templates/rpi3-stretch-arm64-4.14.y
@@ -11,5 +11,5 @@ QEMU_BINARY=/usr/bin/qemu-aarch64-static
 KERNEL_DEFCONFIG=bcmrpi3_defconfig
 KERNEL_BIN_IMAGE=Image
 KERNEL_IMAGE=kernel8.img
-KERNEL_BRANCH=rpi-4.11.y
+KERNEL_BRANCH=rpi-4.14.y
 ENABLE_WIRELESS=true


### PR DESCRIPTION
4.14.y is used as default kernel version of many distros. Additionnaly the 4.14.y branch is the current default branch of the RPi kernel repo.