### PR TITLE
Dropbear

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,12 @@ Set cipher specification string. `aes-xts*` ciphers are strongly recommended.
 ##### `CRYPTFS_XTSKEYSIZE`=512
 Sets key size in bits. The argument has to be a multiple of 8.
 
+##### `CRYPTFS_DROPBEAR`=false
+Enable Dropbear Initramfs support
+
+##### `CRYPTFS_DROPBEAR_PUBKEY`=""
+Provide path to dropbear Public RSA-OpenSSH Key
+
 ---
 
 #### Build settings:

--- a/bootstrap.d/14-fstab.sh
+++ b/bootstrap.d/14-fstab.sh
@@ -29,7 +29,7 @@ if [ "$ENABLE_CRYPTFS" = true ] ; then
 fi
 
 # Generate initramfs file
-if [ "$BUILD_KERNEL" = true ] && [ "$ENABLE_INITRAMFS" = true ] ; then
+if [ "$ENABLE_INITRAMFS" = true ] ; then
   if [ "$ENABLE_CRYPTFS" = true ] ; then
     # Include initramfs scripts to auto expand encrypted root partition
     if [ "$EXPANDROOT" = true ] ; then
@@ -38,8 +38,43 @@ if [ "$BUILD_KERNEL" = true ] && [ "$ENABLE_INITRAMFS" = true ] ; then
       install_exec files/initramfs/expand-tools "${ETC_DIR}/initramfs-tools/hooks/expand-tools"
     fi
 
-    # Disable SSHD inside initramfs
-    printf "#\n# DROPBEAR: [ y | n ]\n#\n\nDROPBEAR=n\n" >> "${ETC_DIR}/initramfs-tools/initramfs.conf"
+	if [ "$CRYPTFS_DROPBEAR" = true ]; then
+		if [ -n "$CRYPTFS_DROPBEAR_PUBKEY" ] && [ -f "$CRYPTFS_DROPBEAR_PUBKEY" ] ; then
+ 			install_readonly "${CRYPTFS_DROPBEAR_PUBKEY}" "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
+ 			cat "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub >> "${ETC_DIR}"/dropbear-initramfs/authorized_keys
+ 		else
+  		  # Create key
+ 		  chroot_exec /usr/bin/dropbearkey -t rsa -f /etc/dropbear-initramfs/id_rsa.dropbear
+
+ 		  # Convert dropbear key to openssh key
+ 		  chroot_exec /usr/lib/dropbear/dropbearconvert dropbear openssh /etc/dropbear-initramfs/id_rsa.dropbear /etc/dropbear-initramfs/id_rsa
+
+		  # Get Public Key Part
+ 		  chroot_exec /usr/bin/dropbearkey -y -f /etc/dropbear-initramfs/id_rsa.dropbear | chroot_exec tee /etc/dropbear-initramfs/id_rsa.pub
+
+		  # Delete unwanted lines
+ 		  sed -i '/Public/d' "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
+ 		  sed -i '/Fingerprint/d' "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
+
+		  # Trust the new key
+ 		  cat "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub > "${ETC_DIR}"/dropbear-initramfs/authorized_keys
+
+          # Save Keys - convert with putty from rsa/openssh to puttkey
+          cp -f "${ETC_DIR}"/dropbear-initramfs/id_rsa "${BASEDIR}"/dropbear_initramfs_key.rsa
+
+		  # Get unlock script
+ 		  install_exec files/initramfs/crypt_unlock.sh "${ETC_DIR}"/initramfs-tools/hooks/crypt_unlock.sh
+
+		  # Enable Dropbear inside initramfs
+	      printf "#\n# DROPBEAR: [ y | n ]\n#\n\nDROPBEAR=y\n" >> "${ETC_DIR}/initramfs-tools/initramfs.conf"
+
+	      # Enable Dropbear inside initramfs
+	      sed -i "54 i sleep 5" "${R}"/usr/share/initramfs-tools/scripts/init-premount/dropbear	  
+		fi
+	else
+	  # Disable SSHD inside initramfs
+	  printf "#\n# DROPBEAR: [ y | n ]\n#\n\nDROPBEAR=n\n" >> "${ETC_DIR}/initramfs-tools/initramfs.conf"
+	fi
 
     # Add cryptsetup modules to initramfs
     printf "#\n# CRYPTSETUP: [ y | n ]\n#\n\nCRYPTSETUP=y\n" >> "${ETC_DIR}/initramfs-tools/conf-hook"

--- a/bootstrap.d/15-rpi-config.sh
+++ b/bootstrap.d/15-rpi-config.sh
@@ -87,7 +87,7 @@ if [ "$ENABLE_TURBO" = true ] ; then
 fi
 
 if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
-  
+
   # Bluetooth enabled
   if [ "$ENABLE_BLUETOOTH" = true ] ; then
     # Create temporary directory for Bluetooth sources
@@ -109,7 +109,7 @@ if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
     # Install tools
     install_readonly "${R}/tmp/pi-bluetooth/usr/bin/btuart" "${R}/usr/bin/btuart"
     install_readonly "${R}/tmp/pi-bluetooth/usr/bin/bthelper" "${R}/usr/bin/bthelper"
-	
+
 	# make scripts executable
 	chmod +x "${R}/usr/bin/bthelper"
 	chmod +x "${R}/usr/bin/btuart"
@@ -123,11 +123,11 @@ if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
     install_readonly "${R}/tmp/pi-bluetooth/BCM43430A1.hcd" "${BLUETOOTH_FIRMWARE_DIR}/LICENCE.broadcom_bcm43xx"
     install_readonly "${R}/tmp/pi-bluetooth/debian/pi-bluetooth.bthelper@.service" "${ETC_DIR}/systemd/system/pi-bluetooth.bthelper@.service"
     install_readonly "${R}/tmp/pi-bluetooth/debian/pi-bluetooth.hciuart.service" "${ETC_DIR}/systemd/system/pi-bluetooth.hciuart.service"
-	
+
     # Remove temporary directories
     rm -fr "${temp_dir}"
 	rm -fr "${R}"/tmp/pi-bluetooth
-	
+
     # Switch Pi3 Bluetooth function to use the mini-UART (ttyS0) and restore UART0/ttyAMA0 over GPIOs 14 & 15. Slow Bluetooth and slow cpu. Use /dev/ttyS0 instead of /dev/ttyAMA0
     if [ "$ENABLE_MINIUART_OVERLAY" = true ] ; then
 
@@ -139,10 +139,10 @@ if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
 	    echo "core_freq=250" >> "${BOOT_DIR}/config.txt"
 	  fi
 	fi
-		  
+
 	# Activate services
 	chroot_exec systemctl enable pi-bluetooth.hciuart.service
-	
+
   else # if ENABLE_BLUETOOTH = false
   	# set overlay to disable bluetooth
     echo "dtoverlay=pi3-disable-bt" >> "${BOOT_DIR}/config.txt"
@@ -154,7 +154,7 @@ if [ "$ENABLE_CONSOLE" = true ] ; then
   echo "enable_uart=1"  >> "${BOOT_DIR}/config.txt" 
   # add string to cmdline
   CMDLINE="${CMDLINE} console=serial0,115200"
-	  
+
   # Enable serial console systemd style
   chroot_exec systemctl enable serial-getty\@serial0.service
 else

--- a/bootstrap.d/20-networking.sh
+++ b/bootstrap.d/20-networking.sh
@@ -57,6 +57,20 @@ else # ENABLE_DHCP=false
   -e "0,/NTP=\$/ s|NTP=\$|NTP=${NET_NTP_1}|"\
   -e "0,/NTP=\$/ s|NTP=\$|NTP=${NET_NTP_2}|"\
   "${ETC_DIR}/systemd/network/eth.network"
+  
+  if [ "$CRYPTFS_DROPBEAR" = true ] ; then
+    # Get cdir from NET_ADDRESS e.g. 24
+    cdir=$(${NET_ADDRESS} | cut -d '/' -f2)
+
+    # Convert cdir ro netmask e.g. 24 to 255.255.255.0
+    NET_MASK=$(cdr2mask "$cdir")
+	
+	# Write static ip settings to "${ETC_DIR}"/initramfs-tools/initramfs.conf
+    sed -i "\$aIP=${NET_ADDRESS}::${NET_GATEWAY}:${NET_MASK}:${HOSTNAME}:" "${ETC_DIR}"/initramfs-tools/initramfs.conf
+
+	# Regenerate initramfs
+	chroot_exec mkinitramfs -o "/boot/firmware/initramfs-${KERNEL_VERSION}" "${KERNEL_VERSION}"
+  fi
 fi
 
 # Remove empty settings from network configuration

--- a/bootstrap.d/21-firewall.sh
+++ b/bootstrap.d/21-firewall.sh
@@ -27,6 +27,9 @@ if [ "$ENABLE_IPTABLES" = true ] ; then
   chroot_exec systemctl enable iptables.service
 
   if [ "$ENABLE_IPV6" = true ] ; then
+    # make sure ip6tables-legacy is the used alternatives 
+    chroot_exec update-alternatives --verbose --set ip6tables /usr/sbin/ip6tables-legacy
+	
     # Install ip6tables systemd service
     install_readonly files/iptables/ip6tables.service "${ETC_DIR}/systemd/system/ip6tables.service"
 

--- a/bootstrap.d/30-security.sh
+++ b/bootstrap.d/30-security.sh
@@ -22,8 +22,3 @@ else
   # Set no root password to disable root login
   chroot_exec usermod -p \'!\' root
 fi
-
-# Enable serial console systemd style
-if [ "$ENABLE_CONSOLE" = true ] ; then
-  chroot_exec systemctl enable serial-getty\@ttyAMA0.service
-fi

--- a/bootstrap.d/43-videocore.sh
+++ b/bootstrap.d/43-videocore.sh
@@ -50,4 +50,7 @@ if [ "$ENABLE_VIDEOCORE" = true ] ; then
 
   #back to root of scriptdir
   cd "${WORKDIR}"
+  
+  # Remove videocore sources
+  rm -fr "${R}"/tmp/userland/
 fi

--- a/files/firstboot/23-regenerate-initramfs.sh
+++ b/files/firstboot/23-regenerate-initramfs.sh
@@ -8,6 +8,7 @@ INITRAMFS_UBOOT="${INITRAMFS}.uboot"
 # Extract kernel arch
 case "${KERNEL_ARCH}" in
   arm*) KERNEL_ARCH=arm ;;
+  aarch64) KERNEL_ARCH=arm64 ;;
 esac
 
 # Regenerate initramfs

--- a/files/initramfs/crypt_unlock.sh
+++ b/files/initramfs/crypt_unlock.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+PREREQ="dropbear"
+
+prereqs() {
+echo "$PREREQ"
+}
+
+case "$1" in
+prereqs)
+prereqs
+exit 0
+;;
+esac
+
+. "${CONFDIR}/initramfs.conf"
+. /usr/share/initramfs-tools/hook-functions
+
+if [ "${DROPBEAR}" != "n" ] && [ -r "/etc/crypttab" ] ; then
+cat > "${DESTDIR}/bin/unlock" << EOF
+#!/bin/sh
+if PATH=/lib/unlock:/bin:/sbin /scripts/local-top/cryptroot; then
+kill \`ps | grep cryptroot | grep -v "grep" | awk '{print \$1}'\`
+# following line kill the remote shell right after the passphrase has
+# been entered.
+kill -9 \`ps | grep "\-sh" | grep -v "grep" | awk '{print \$1}'\`
+exit 0
+fi
+exit 1
+EOF
+
+chmod 755 "${DESTDIR}/bin/unlock"
+
+mkdir -p "${DESTDIR}/lib/unlock"
+cat > "${DESTDIR}/lib/unlock/plymouth" << EOF
+#!/bin/sh
+[ "\$1" == "--ping" ] && exit 1
+/bin/plymouth "\$@"
+EOF
+
+chmod 755 "${DESTDIR}/lib/unlock/plymouth"
+
+echo To unlock root-partition run "unlock" >> ${DESTDIR}/etc/motd
+
+fi

--- a/functions.sh
+++ b/functions.sh
@@ -63,15 +63,15 @@ chroot_install_cc() {
   # Install c/c++ build environment inside the chroot
   if [ -z "${COMPILER_PACKAGES}" ] ; then
     COMPILER_PACKAGES=$(chroot_exec apt-get -s install g++ make bc | grep "^Inst " | awk -v ORS=" " '{ print $2 }')
-	# Install COMPILER_PACKAGES in chroot
-    chroot_exec apt-get -q -y --allow-unauthenticated --no-install-recommends install "${COMPILER_PACKAGES}"
+	# Install COMPILER_PACKAGES in chroot - NEVER do "${COMPILER_PACKAGES}" -> breaks uboot
+    chroot_exec apt-get -q -y --allow-unauthenticated --no-install-recommends install ${COMPILER_PACKAGES}
   fi
 }
 
 chroot_remove_cc() {
   # Remove c/c++ build environment from the chroot
   if [ -n "${COMPILER_PACKAGES}" ] ; then
-    chroot_exec apt-get -qq -y --auto-remove purge "${COMPILER_PACKAGES}"
+    chroot_exec apt-get -qq -y --auto-remove purge ${COMPILER_PACKAGES}
     COMPILER_PACKAGES=""
   fi
 }

--- a/functions.sh
+++ b/functions.sh
@@ -75,3 +75,12 @@ chroot_remove_cc() {
     COMPILER_PACKAGES=""
   fi
 }
+
+# https://serverfault.com/a/682849 - converts e.g. /24 to 255.255.255.0
+cdr2mask ()
+{
+   # Number of args to shift, 255..255, first non-255 byte, zeroes
+   set -- $(( 5 - ($1 / 8) )) 255 255 255 255 $(( (255 << (8 - ($1 % 8))) & 255 )) 0 0 0
+   [ $1 -gt 1 ] && shift $1 || shift
+   echo ${1-0}.${2-0}.${3-0}.${4-0}
+}


### PR DESCRIPTION
static ip in dropbear needs a tester. didn't noticed any error with dynamic ip 

- Enable dropbear in initramfs with cryptfs_cropbear=true
- dropbear initramfs supports static and dyn. ip - dropbear uses provided ip_config NET_*
- bluetooth with serial improved
- ipv6 legacy firewalling
- add cleanup to videocore
- improved apt-cacher-ng detection