### PR TITLE
Pull

### DIFF
--- a/bootstrap.d/13-kernel.sh
+++ b/bootstrap.d/13-kernel.sh
@@ -501,7 +501,7 @@ if [ "$BUILD_KERNEL" = true ] ; then
 
   # Copy compiled dtb device tree files
   if [ -d "${KERNEL_DIR}/arch/${KERNEL_ARCH}/boot/dts/overlays" ] ; then
-    for dtb in "${KERNEL_DIR}/arch/${KERNEL_ARCH}/boot/dts/overlays/"*.dtb ; do
+    for dtb in "${KERNEL_DIR}/arch/${KERNEL_ARCH}/boot/dts/overlays/"*.dtbo ; do
       if [ -f "${dtb}" ] ; then
         install_readonly "${dtb}" "${BOOT_DIR}/overlays/"
       fi

--- a/bootstrap.d/13-kernel.sh
+++ b/bootstrap.d/13-kernel.sh
@@ -161,20 +161,20 @@ if [ "$BUILD_KERNEL" = true ] ; then
         set_kernel_config CONFIG_AUDIT y
 
         # harden strcpy and memcpy
-        set_kernel_config CONFIG_HARDENED_USERCOPY=y
-        set_kernel_config CONFIG_HAVE_HARDENED_USERCOPY_ALLOCATOR=y
-        set_kernel_config CONFIG_FORTIFY_SOURCE=y
+        set_kernel_config CONFIG_HARDENED_USERCOPY y
+        set_kernel_config CONFIG_HAVE_HARDENED_USERCOPY_ALLOCATOR y
+        set_kernel_config CONFIG_FORTIFY_SOURCE y
 
         # integrity sub-system
-        set_kernel_config CONFIG_INTEGRITY=y
-        set_kernel_config CONFIG_INTEGRITY_ASYMMETRIC_KEYS=y
-        set_kernel_config CONFIG_INTEGRITY_AUDIT=y
-        set_kernel_config CONFIG_INTEGRITY_SIGNATURE=y
-        set_kernel_config CONFIG_INTEGRITY_TRUSTED_KEYRING=y
+        set_kernel_config CONFIG_INTEGRITY y
+        set_kernel_config CONFIG_INTEGRITY_ASYMMETRIC_KEYS y
+        set_kernel_config CONFIG_INTEGRITY_AUDIT y
+        set_kernel_config CONFIG_INTEGRITY_SIGNATURE y
+        set_kernel_config CONFIG_INTEGRITY_TRUSTED_KEYRING y
 
         # This option provides support for retaining authentication tokens and access keys in the kernel.
-        set_kernel_config CONFIG_KEYS=y
-        set_kernel_config CONFIG_KEYS_COMPAT=y
+        set_kernel_config CONFIG_KEYS y
+        set_kernel_config CONFIG_KEYS_COMPAT y
 
         # Apparmor
         set_kernel_config CONFIG_SECURITY_APPARMOR_BOOTPARAM_VALUE 0
@@ -185,13 +185,13 @@ if [ "$BUILD_KERNEL" = true ] ; then
         set_kernel_config CONFIG_DEFAULT_SECURITY "apparmor"
 
         # restrictions on unprivileged users reading the kernel
-        set_kernel_config CONFIG_SECURITY_DMESG_RESTRICT=y
+        set_kernel_config CONFIG_SECURITY_DMESG_RESTRICT y
 
         # network security hooks
         set_kernel_config CONFIG_SECURITY_NETWORK y
-        set_kernel_config CONFIG_SECURITY_NETWORK_XFRM=y
-        set_kernel_config CONFIG_SECURITY_PATH=y
-        set_kernel_config CONFIG_SECURITY_YAMA=y
+        set_kernel_config CONFIG_SECURITY_NETWORK_XFRM y
+        set_kernel_config CONFIG_SECURITY_PATH y
+        set_kernel_config CONFIG_SECURITY_YAMA n
 
         # New Options
         if [ "$KERNEL_NF" = true ] ; then

--- a/bootstrap.d/14-fstab.sh
+++ b/bootstrap.d/14-fstab.sh
@@ -45,40 +45,54 @@ if [ "$ENABLE_INITRAMFS" = true ] ; then
       install_exec files/initramfs/expand-premount "${ETC_DIR}/initramfs-tools/scripts/local-premount/expand-premount"
       install_exec files/initramfs/expand-tools "${ETC_DIR}/initramfs-tools/hooks/expand-tools"
     fi
+	
+	if [ "$ENABLE_DHCP" = false ] ; then
+      # Get cdir from NET_ADDRESS e.g. 24
+      cdir=$(${NET_ADDRESS} | cut -d '/' -f2)
+
+      # Convert cdir ro netmask e.g. 24 to 255.255.255.0
+      NET_MASK=$(cdr2mask "$cdir")
+	
+	  # Write static ip settings to "${ETC_DIR}"/initramfs-tools/initramfs.conf
+      sed -i "\$aIP=${NET_ADDRESS}::${NET_GATEWAY}:${NET_MASK}:${HOSTNAME}:" "${ETC_DIR}"/initramfs-tools/initramfs.conf
+
+	  # Regenerate initramfs
+	  chroot_exec mkinitramfs -o "/boot/firmware/initramfs-${KERNEL_VERSION}" "${KERNEL_VERSION}"
+    fi
 
 	if [ "$CRYPTFS_DROPBEAR" = true ]; then
-		if [ -n "$CRYPTFS_DROPBEAR_PUBKEY" ] && [ -f "$CRYPTFS_DROPBEAR_PUBKEY" ] ; then
- 			install_readonly "${CRYPTFS_DROPBEAR_PUBKEY}" "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
- 			cat "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub >> "${ETC_DIR}"/dropbear-initramfs/authorized_keys
- 		else
-  		  # Create key
- 		  chroot_exec /usr/bin/dropbearkey -t rsa -f /etc/dropbear-initramfs/id_rsa.dropbear
+	  if [ -n "$CRYPTFS_DROPBEAR_PUBKEY" ] && [ -f "$CRYPTFS_DROPBEAR_PUBKEY" ] ; then
+ 	    install_readonly "${CRYPTFS_DROPBEAR_PUBKEY}" "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
+ 	    cat "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub >> "${ETC_DIR}"/dropbear-initramfs/authorized_keys
+ 	  else
+ 	    # Create key
+ 	    chroot_exec /usr/bin/dropbearkey -t rsa -f /etc/dropbear-initramfs/id_rsa.dropbear
 
- 		  # Convert dropbear key to openssh key
- 		  chroot_exec /usr/lib/dropbear/dropbearconvert dropbear openssh /etc/dropbear-initramfs/id_rsa.dropbear /etc/dropbear-initramfs/id_rsa
+ 	    # Convert dropbear key to openssh key
+ 	    chroot_exec /usr/lib/dropbear/dropbearconvert dropbear openssh /etc/dropbear-initramfs/id_rsa.dropbear /etc/dropbear-initramfs/id_rsa
 
-		  # Get Public Key Part
- 		  chroot_exec /usr/bin/dropbearkey -y -f /etc/dropbear-initramfs/id_rsa.dropbear | chroot_exec tee /etc/dropbear-initramfs/id_rsa.pub
+ 	    # Get Public Key Part
+ 	    chroot_exec /usr/bin/dropbearkey -y -f /etc/dropbear-initramfs/id_rsa.dropbear | chroot_exec tee /etc/dropbear-initramfs/id_rsa.pub
 
-		  # Delete unwanted lines
- 		  sed -i '/Public/d' "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
- 		  sed -i '/Fingerprint/d' "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
+ 	    # Delete unwanted lines
+ 	    sed -i '/Public/d' "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
+ 	    sed -i '/Fingerprint/d' "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
 
-		  # Trust the new key
- 		  cat "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub > "${ETC_DIR}"/dropbear-initramfs/authorized_keys
+ 	    # Trust the new key
+ 	    cat "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub > "${ETC_DIR}"/dropbear-initramfs/authorized_keys
 
-          # Save Keys - convert with putty from rsa/openssh to puttkey
-          cp -f "${ETC_DIR}"/dropbear-initramfs/id_rsa "${BASEDIR}"/dropbear_initramfs_key.rsa
+ 	    # Save Keys - convert with putty from rsa/openssh to puttkey
+ 	    cp -f "${ETC_DIR}"/dropbear-initramfs/id_rsa "${BASEDIR}"/dropbear_initramfs_key.rsa
 
-		  # Get unlock script
- 		  install_exec files/initramfs/crypt_unlock.sh "${ETC_DIR}"/initramfs-tools/hooks/crypt_unlock.sh
+ 	    # Get unlock script
+ 	    install_exec files/initramfs/crypt_unlock.sh "${ETC_DIR}"/initramfs-tools/hooks/crypt_unlock.sh
 
-		  # Enable Dropbear inside initramfs
-	      printf "#\n# DROPBEAR: [ y | n ]\n#\n\nDROPBEAR=y\n" >> "${ETC_DIR}/initramfs-tools/initramfs.conf"
+ 	    # Enable Dropbear inside initramfs
+ 	    printf "#\n# DROPBEAR: [ y | n ]\n#\n\nDROPBEAR=y\n" >> "${ETC_DIR}/initramfs-tools/initramfs.conf"
 
-	      # Enable Dropbear inside initramfs
-	      sed -i "54 i sleep 5" "${R}"/usr/share/initramfs-tools/scripts/init-premount/dropbear	  
-		fi
+ 	    # Enable Dropbear inside initramfs
+ 	    sed -i "54 i sleep 5" "${R}"/usr/share/initramfs-tools/scripts/init-premount/dropbear	  
+	  fi
 	else
 	  # Disable SSHD inside initramfs
 	  printf "#\n# DROPBEAR: [ y | n ]\n#\n\nDROPBEAR=n\n" >> "${ETC_DIR}/initramfs-tools/initramfs.conf"

--- a/bootstrap.d/14-fstab.sh
+++ b/bootstrap.d/14-fstab.sh
@@ -8,11 +8,6 @@
 # Install and setup fstab
 install_readonly files/mount/fstab "${ETC_DIR}/fstab"
 
-if [ "$ENABLE_UBOOTUSB" = true ] ; then
-  sed -i "s/mmcblk0p1/sda1/" "${ETC_DIR}/fstab"
-  sed -i "s/mmcblk0p2/sda2/" "${ETC_DIR}/fstab"
-fi
-
 # Add usb/sda disk root partition to fstab
 if [ "$ENABLE_SPLITFS" = true ] && [ "$ENABLE_CRYPTFS" = false ] ; then
   sed -i "s/mmcblk0p2/sda1/" "${ETC_DIR}/fstab"
@@ -28,9 +23,17 @@ if [ "$ENABLE_CRYPTFS" = true ] ; then
   echo "${CRYPTFS_MAPPING} /dev/mmcblk0p2 none luks,initramfs" >> "${ETC_DIR}/crypttab"
 
   if [ "$ENABLE_SPLITFS" = true ] ; then
-    # Add usb/sda disk to crypttab
+    # Add usb/sda1 disk to crypttab
     sed -i "s/mmcblk0p2/sda1/" "${ETC_DIR}/crypttab"
   fi
+fi
+
+if [ "$ENABLE_USBBOOT" = true ] ; then
+  sed -i "s/mmcblk0p1/sda1/" "${ETC_DIR}/fstab"
+  sed -i "s/mmcblk0p2/sda2/" "${ETC_DIR}/fstab"
+
+  # Add usb/sda2 disk to crypttab
+  sed -i "s/mmcblk0p2/sda2/" "${ETC_DIR}/crypttab"
 fi
 
 # Generate initramfs file

--- a/bootstrap.d/15-rpi-config.sh
+++ b/bootstrap.d/15-rpi-config.sh
@@ -156,14 +156,13 @@ if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
 
     # Switch Pi3 Bluetooth function to use the mini-UART (ttyS0) and restore UART0/ttyAMA0 over GPIOs 14 & 15. Slow Bluetooth and slow cpu. Use /dev/ttyS0 instead of /dev/ttyAMA0
     if [ "$ENABLE_MINIUART_OVERLAY" = true ] ; then
-
 	  # set overlay to swap ttyAMA0 and ttyS0
       echo "dtoverlay=pi3-miniuart-bt" >> "${BOOT_DIR}/config.txt"
 
-	  # if force_turbo didn't lock cpu at high speed, lock it at low speed (XOR logic) or miniuart will be broken
 	  if [ "$ENABLE_TURBO" = false ] ; then 
-	    echo "core_freq=250" >> "${BOOT_DIR}/config.txt"
-	  fi
+        echo "core_freq=250" >> "${BOOT_DIR}/config.txt"
+      fi 
+	  
 	fi
 
 	# Activate services
@@ -180,14 +179,18 @@ if [ "$ENABLE_CONSOLE" = true ] ; then
   echo "enable_uart=1"  >> "${BOOT_DIR}/config.txt" 
   # add string to cmdline
   CMDLINE="${CMDLINE} console=serial0,115200"
+  
+  if [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ]|| [ "$RPI_MODEL" = 0 ]; then
+    # if force_turbo didn't lock cpu at high speed, lock it at low speed (XOR logic) or miniuart will be broken
+    if [ "$ENABLE_TURBO" = false ] ; then 
+      echo "core_freq=250" >> "${BOOT_DIR}/config.txt"
+    fi 
+  fi
 
   # Enable serial console systemd style
-  chroot_exec systemctl enable serial-getty\@serial0.service
+  chroot_exec systemctl enable serial-getty@serial0.service
 else
   echo "enable_uart=0"  >> "${BOOT_DIR}/config.txt"
-  
-  # disable serial console systemd style
-  chroot_exec systemctl disable serial-getty\@"$SET_SERIAL".service
 fi
 
 if [ "$ENABLE_SYSTEMDSWAP" = true ] ; then
@@ -200,36 +203,35 @@ if [ "$ENABLE_SYSTEMDSWAP" = true ] ; then
   # Copy downloaded systemd-swap sources
   mv "${temp_dir}/systemd-swap" "${R}/tmp/"
 
-  # Set permissions of the systemd-swap sources
-  chown -R root:root "${R}/tmp/systemd-swap"
-
-  # Remove temporary directory for systemd-swap sources
-  rm -fr "${temp_dir}"
-  
   # Change into downloaded src dir
   cd "${R}/tmp/systemd-swap" || exit
-  
+
   # Build package
-  . ./package.sh debian
-  
-  # Install package
-  chroot_exec dpkg -i /tmp/systemd-swap/systemd-swap-*any.deb
-  
-  # Enable service
-  chroot_exec systemctl enable systemd-swap
+  bash ./package.sh debian
   
   # Change back into script root dir
   cd "${WORKDIR}" || exit
+  
+  # Set permissions of the systemd-swap sources
+  chown -R root:root "${R}/tmp/systemd-swap"
+
+  # Install package - IMPROVE AND MAKE IT POSSIBLE WITHOUT VERSION NR.
+  chroot_exec dpkg -i /tmp/systemd-swap/systemd-swap_4.0.1_any.deb
+
+  # Enable service
+  chroot_exec systemctl enable systemd-swap
+  
+  # Remove temporary directory for systemd-swap sources
+  rm -fr "${temp_dir}"
 else
   # Enable ZSWAP in cmdline if systemd-swap is not used
   if [ "$KERNEL_ZSWAP" = true ] ; then
-    CMDLINE="${CMDLINE} zswap.enabled=1 zswap.max_pool_percent=25 zswap.compressor=lz4" 
+    CMDLINE="${CMDLINE} zswap.enabled=1 zswap.max_pool_percent=25 zswap.compressor=lz4"
   fi
 fi
-
-if [ "$KERNEL_SECURITY" = true ] ; then
-  CMDLINE="${CMDLINE} apparmor=1 security=apparmor" 
-fi
+  if [ "$KERNEL_SECURITY" = true ] ; then
+    CMDLINE="${CMDLINE} apparmor=1 security=apparmor" 
+  fi
 
 # Install firmware boot cmdline
 echo "${CMDLINE}" > "${BOOT_DIR}/cmdline.txt"

--- a/bootstrap.d/20-networking.sh
+++ b/bootstrap.d/20-networking.sh
@@ -30,6 +30,10 @@ install_readonly files/network/interfaces "${ETC_DIR}/network/interfaces"
 # Install configuration for interface eth0
 install_readonly files/network/eth.network "${ETC_DIR}/systemd/network/eth.network"
 
+if [ "$RPI_MODEL" = 3P ] ; then
+printf "\n[Link]\nGenericReceiveOffload=off\nTCPSegmentationOffload=off\nGenericSegmentationOffload=off" >> "${ETC_DIR}/systemd/network/eth.network"
+fi
+
 # Install configuration for interface wl*
 install_readonly files/network/wlan.network "${ETC_DIR}/systemd/network/wlan.network"
 

--- a/bootstrap.d/20-networking.sh
+++ b/bootstrap.d/20-networking.sh
@@ -57,20 +57,6 @@ else # ENABLE_DHCP=false
   -e "0,/NTP=\$/ s|NTP=\$|NTP=${NET_NTP_1}|"\
   -e "0,/NTP=\$/ s|NTP=\$|NTP=${NET_NTP_2}|"\
   "${ETC_DIR}/systemd/network/eth.network"
-  
-  if [ "$CRYPTFS_DROPBEAR" = true ] ; then
-    # Get cdir from NET_ADDRESS e.g. 24
-    cdir=$(${NET_ADDRESS} | cut -d '/' -f2)
-
-    # Convert cdir ro netmask e.g. 24 to 255.255.255.0
-    NET_MASK=$(cdr2mask "$cdir")
-	
-	# Write static ip settings to "${ETC_DIR}"/initramfs-tools/initramfs.conf
-    sed -i "\$aIP=${NET_ADDRESS}::${NET_GATEWAY}:${NET_MASK}:${HOSTNAME}:" "${ETC_DIR}"/initramfs-tools/initramfs.conf
-
-	# Regenerate initramfs
-	chroot_exec mkinitramfs -o "/boot/firmware/initramfs-${KERNEL_VERSION}" "${KERNEL_VERSION}"
-  fi
 fi
 
 # Remove empty settings from network configuration

--- a/bootstrap.d/21-firewall.sh
+++ b/bootstrap.d/21-firewall.sh
@@ -10,7 +10,7 @@ if [ "$ENABLE_IPTABLES" = true ] ; then
   mkdir -p "${ETC_DIR}/iptables"
   
   if [ "$KERNEL_NF" = false ] ; then
-    #iptables-save and -restore are slaves of iptables and thus are set accordingly
+    # iptables-save and -restore are slaves of iptables and thus are set accordingly
     chroot_exec update-alternatives --verbose --set iptables /usr/sbin/iptables-legacy    
   fi
   
@@ -29,10 +29,10 @@ if [ "$ENABLE_IPTABLES" = true ] ; then
 
   if [ "$ENABLE_IPV6" = true ] ; then
     if [ "$KERNEL_NF" = false ] ; then
-      #iptables-save and -restore are slaves of iptables and thus are set accordingly
+      # iptables-save and -restore are slaves of iptables and thus are set accordingly
       chroot_exec update-alternatives --verbose --set ip6tables /usr/sbin/ip6tables-legacy 
-	  fi
-    
+	fi
+
     # Install ip6tables systemd service
     install_readonly files/iptables/ip6tables.service "${ETC_DIR}/systemd/system/ip6tables.service"
 

--- a/bootstrap.d/41-uboot.sh
+++ b/bootstrap.d/41-uboot.sh
@@ -79,7 +79,7 @@ if [ "$ENABLE_UBOOT" = true ] ; then
   fi
   
   # instead of sd, boot from usb device
-  if [ "$ENABLE_UBOOTUSB" = true ] ; then
+  if [ "$ENABLE_USBBOOT" = true ] ; then
     sed -i "s|mmc|usb|g" "${BOOT_DIR}/uboot.mkimage"
   fi
 

--- a/files/apt/flash-kernel
+++ b/files/apt/flash-kernel
@@ -1,3 +1,0 @@
-Package: flash-kernel
-Pin: origin repositories.collabora.co.uk
-Pin-Priority: 1000

--- a/files/sysctl.d/84-rpi-ASLR.conf
+++ b/files/sysctl.d/84-rpi-ASLR.conf
@@ -1,0 +1,2 @@
+# ASLR
+kernel.randomize_va_space = 2

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -719,7 +719,7 @@ if [ "$ENABLE_QEMU" = true ] ; then
     # Setup overlays dtbs directory
     mkdir "${BASEDIR}/qemu/overlays"
 
-    for dtb in "${BOOT_DIR}/overlays/"*.dtb ; do
+    for dtb in "${BOOT_DIR}/overlays/"*.dtbo ; do
       if [ -f "${dtb}" ] ; then
         install_readonly "${dtb}" "${BASEDIR}/qemu/overlays/"
       fi

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -158,7 +158,7 @@ ENABLE_MINBASE=${ENABLE_MINBASE:=false}
 ENABLE_REDUCE=${ENABLE_REDUCE:=false}
 ENABLE_UBOOT=${ENABLE_UBOOT:=false}
 UBOOTSRC_DIR=${UBOOTSRC_DIR:=""}
-ENABLE_UBOOTUSB=${ENABLE_UBOOTUSB=false}
+ENABLE_USBBOOT=${ENABLE_USBBOOT=false}
 ENABLE_FBTURBO=${ENABLE_FBTURBO:=false}
 ENABLE_VIDEOCORE=${ENABLE_VIDEOCORE:=false}
 ENABLE_NEXMON=${ENABLE_NEXMON:=false}
@@ -325,17 +325,6 @@ case "$RPI_MODEL" in
     ;;
 esac
 
-if [ "$ENABLE_UBOOTUSB" = true ] ; then
-  if [ "$ENABLE_UBOOT" = false ] ; then
-    echo "error: Enabling UBOOTUSB requires u-boot to be enabled"
-	exit 1
-  fi
-  if [ "$RPI_MODEL" != 3 ] || [ "$RPI_MODEL" != 3P ] ; then
-    echo "error: Enabling UBOOTUSB requires Raspberry 3"
-	exit 1
-  fi
-fi
-
 # Raspberry PI 0,3,3P with Bluetooth and Wifi onboard
 if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
   # Include bluetooth packages on supported boards
@@ -419,6 +408,13 @@ fi
 # Add device-tree-compiler required for building the U-Boot bootloader
 if [ "$ENABLE_UBOOT" = true ] ; then
   APT_INCLUDES="${APT_INCLUDES},device-tree-compiler,bison,flex,bc"
+fi
+
+if [ "$ENABLE_USBBOOT" = true ] ; then 
+  if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 1P ] || [ "$RPI_MODEL" = 1 ] || [ "$RPI_MODEL" = 2 ]; then
+    echo "error: Booting from USB alone is only supported by Raspberry Pi 3 and 3P"
+    exit 1
+  fi
 fi
 
 # Check if root SSH (v2) public key file exists


### PR DESCRIPTION
- Usboot is back now working with uboot and without
- dropbear static ip fixed
- Removed upstream SD_Host kernel driver as it conflicted with RPI-downstream (heavily patched and faster than upstream) driver. Blacklisting is not possible due to beeing build in to the kernel. see [pwellwells post](https://www.raspberrypi.org/forums/viewtopic.php?t=210225)
- fixed device tree overlay