### PR TITLE
11-apt.sh: Fixed APT_INCLUDES_LATE

### DIFF
--- a/bootstrap.d/11-apt.sh
+++ b/bootstrap.d/11-apt.sh
@@ -24,7 +24,7 @@ chroot_exec apt-get -qq -y -u dist-upgrade
 
 # Install additional packages
 if [ "$APT_INCLUDES_LATE" ] ; then
-  chroot_exec apt-get -qq -y install "$(echo "$APT_INCLUDES_LATE" |tr , ' ')"
+  chroot_exec apt-get -qq -y install $(echo "$APT_INCLUDES_LATE" |tr , ' ')
 fi
 
 # Install Debian custom packages


### PR DESCRIPTION
Hi!

When I set `APT_INCLUDES_LATE` to a comma-separated list of packages `apt-get install` failed, because it treats the package list as single argument. 

`APT_INCLUDES_LATE=net-tools,vim,mc,git,systemd-sysv,tmux,wpasupplicant,ufw`

Output before my fix:
```
+ [ net-tools,vim,mc,git,systemd-sysv,tmux,wpasupplicant,ufw ]
+ echo net-tools,vim,mc,git,systemd-sysv,tmux,wpasupplicant,ufw
+ tr ,  
+ chroot_exec apt-get -qq -y install net-tools vim mc git systemd-sysv tmux wpasupplicant ufw
+ LANG=C LC_ALL=C DEBIAN_FRONTEND=noninteractive chroot /root/rpi23-gen-image/images/stretch-custom/build/chroot apt-get -qq -y install net-tools vim mc git systemd-sysv tmux wpasupplicant ufw
E: Unable to locate package net-tools vim mc git systemd-sysv tmux wpasupplicant ufw
```

Output after my fix:
```
+ [ net-tools,vim,mc,git,systemd-sysv,tmux,wpasupplicant,ufw ]  
+ echo net-tools,vim,mc,git,systemd-sysv,tmux,wpasupplicant,ufw
+ tr ,                                               
+ chroot_exec apt-get -qq -y install net-tools vim mc git systemd-sysv tmux wpasupplicant ufw
+ LANG=C LC_ALL=C DEBIAN_FRONTEND=noninteractive chroot /root/rpi23-gen-image/images/stretch-custom/build/chroot apt-get -qq -y install net-tools vim mc git systemd-sysv tmux wpasupplicant ufw                        
Extracting templates from packages: 100%                  
Preconfiguring packages ...
```

My environment:
```
root@vm-builder01:~/rpi23-gen-image# uname -a
Linux vm-builder01 4.9.0-8-amd64 #1 SMP Debian 4.9.130-2 (2018-10-27) x86_64 GNU/Linux
```

```
root@vm-builder01:~/rpi23-gen-image# lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 9.6 (stretch)
Release:	9.6
Codename:	stretch

```

