### PR TITLE
Fixed setting the timezone

### DIFF
--- a/bootstrap.d/12-locale.sh
+++ b/bootstrap.d/12-locale.sh
@@ -7,6 +7,14 @@
 
 # Install and setup timezone
 echo "${TIMEZONE}" > "${ETC_DIR}/timezone"
+if [ -f "${ETC_DIR}/localtime" ]; then
+    # 1. If 11-apt.sh upgrades the package 'tzdata', '/etc/localtime' was created
+    #    because 'dpkg-reconfigure -f noninteractive tzdata' was executed by apt-get.
+    # 2. If '/etc/localtime' exists, our execution of 'dpkg-reconfigure -f noninteractive tzdata' 
+    #    will ignore the our timezone set in '/etc/timezone'.
+    # 3. Removing /etc/localtime will solve this.
+    rm -f "${ETC_DIR}/localtime"
+fi
 chroot_exec dpkg-reconfigure -f noninteractive tzdata
 
 # Install and setup default locale and keyboard configuration


### PR DESCRIPTION
Hi!
I encountered a bug while bootstrapping Debian Stretch.
Setting the timezone to `Europe/Berlin` had no effect and `Etc/UTC` was still used.
This bug occurs when the package `tzdata` was upgraded during the execution of `11-apt.sh`.

Output of `11-apt.sh`:
```shellscript
+ . bootstrap.d/11-apt.sh
+ . ./functions.sh
+ [ -n http://127.0.0.1:3142/ ]
<snip>
+ chroot_exec apt-get -qq -y -u dist-upgrade
+ LANG=C LC_ALL=C DEBIAN_FRONTEND=noninteractive chroot /<snip>/build/chroot apt-get -qq -y -u dist-upgrade
<snip>
Preparing to unpack .../tzdata_2018i-0+deb9u1_all.deb ...
Unpacking tzdata (2018i-0+deb9u1) over (2018g-0+deb9u1) ...
Setting up tzdata (2018i-0+deb9u1) ...

Current default time zone: 'Etc/UTC'
Local time is now:      Thu Jan 24 09:56:24 UTC 2019.
Universal Time is now:  Thu Jan 24 09:56:24 UTC 2019.
Run 'dpkg-reconfigure tzdata' if you wish to change it.
```
Output of `12-locale.sh` **before** my fix:
```shellscript
#
# Setup Locales and keyboard settings
#
+ . bootstrap.d/12-locale.sh
+ . ./functions.sh
+ echo Europe/Berlin
+ chroot_exec dpkg-reconfigure -f noninteractive tzdata
+ LANG=C LC_ALL=C DEBIAN_FRONTEND=noninteractive chroot /<snip>/build/chroot dpkg-reconfigure -f noninteractive tzdata

Current default time zone: 'Etc/UTC'
Local time is now:      Thu Jan 24 09:59:23 UTC 2019.
Universal Time is now:  Thu Jan 24 09:59:23 UTC 2019.
```
Output of `12-locale.sh` **after** my fix:
```shellscript
#
# Setup Locales and keyboard settings
#
+ . bootstrap.d/12-locale.sh
+ . ./functions.sh
+ echo Europe/Berlin
+ [ -f /<snip>build/chroot/etc/localtime ]
+ rm -f /<snip>/build/chroot/etc/localtime
+ chroot_exec dpkg-reconfigure -f noninteractive tzdata
+ LANG=C LC_ALL=C DEBIAN_FRONTEND=noninteractive chroot /<snip>/build/chroot dpkg-reconfigure -f noninteractive tzdata

Current default time zone: 'Europe/Berlin'
Local time is now:      Thu Jan 24 11:28:55 CET 2019.
Universal Time is now:  Thu Jan 24 10:28:55 UTC 2019.
```


