### PR TITLE
Fix late installing more than one package

### DIFF
--- a/bootstrap.d/11-apt.sh
+++ b/bootstrap.d/11-apt.sh
@@ -24,7 +24,7 @@ chroot_exec apt-get -qq -y -u dist-upgrade
 
 # Install additional packages
 if [ "$APT_INCLUDES_LATE" ] ; then
-  chroot_exec apt-get -qq -y install "$(echo "$APT_INCLUDES_LATE" |tr , ' ')"
+  chroot_exec apt-get -qq -y install $(echo "$APT_INCLUDES_LATE" |tr , ' ')
 fi
 
 # Install Debian custom packages


### PR DESCRIPTION
Fix "Unable to find package" error thrown by apt-get if you put more than one package to `$APT_INCLUDES_LATE`