### PR TITLE
Fixing permission error

### DIFF
--- a/bootstrap.d/11-apt.sh
+++ b/bootstrap.d/11-apt.sh
@@ -16,7 +16,11 @@ install_readonly files/apt/sources.list "${ETC_DIR}/apt/sources.list"
 
 # Use specified APT server and release
 sed -i "s/\/ftp.debian.org\//\/${APT_SERVER}\//" "${ETC_DIR}/apt/sources.list"
+if [ "$RELEASE" = "bullseye" ] || [ "$RELEASE" = "testing" ] ; then
+sed -i "s,stretch\\/updates,testing-security," "${ETC_DIR}/apt/sources.list"
+else
 sed -i "s/ stretch/ ${RELEASE}/" "${ETC_DIR}/apt/sources.list"
+fi
 
 # Upgrade package index and update all installed packages and changed dependencies
 chroot_exec apt-get -qq -y update

--- a/bootstrap.d/13-kernel.sh
+++ b/bootstrap.d/13-kernel.sh
@@ -594,15 +594,15 @@ else # BUILD_KERNEL=false
     chown -R root:root "${R}/lib/modules"
   fi
 
-  # Install Kernel from hypriot comptabile with all Raspberry PI
-  if [ "$SET_ARCH" = 32 ] ; then
+  # Install Kernel from hypriot comptabile with all Raspberry PI (dunno if its compatible with RPI4 - better compile your own kernel)
+  if [ "$SET_ARCH" = 32 ] && [ "$RPI_MODEL" != 4 ] ; then
     # Create temporary directory for dl
     temp_dir=$(as_nobody mktemp -d)
 
     # Fetch kernel
     as_nobody wget -O "${temp_dir}"/kernel.deb -c "$RPI_32_KERNEL_URL"
 
-    # Copy downloaded U-Boot sources
+    # Copy downloaded kernel package
     mv "${temp_dir}"/kernel.deb "${R}"/tmp/kernel.deb
 
     # Set permissions

--- a/bootstrap.d/15-rpi-config.sh
+++ b/bootstrap.d/15-rpi-config.sh
@@ -120,7 +120,7 @@ if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
     temp_dir=$(as_nobody mktemp -d)
 
     # Fetch Bluetooth sources
-    git -C "${temp_dir}" clone "${BLUETOOTH_URL}"
+    as_nobody git -C "${temp_dir}" clone "${BLUETOOTH_URL}"
 
     # Copy downloaded sources
     mv "${temp_dir}/pi-bluetooth" "${R}/tmp/"

--- a/bootstrap.d/15-rpi-config.sh
+++ b/bootstrap.d/15-rpi-config.sh
@@ -126,8 +126,8 @@ if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
     mv "${temp_dir}/pi-bluetooth" "${R}/tmp/"
 
     # Bluetooth firmware from arch aur https://aur.archlinux.org/packages/pi-bluetooth/
-    as_nobody wget -q -O "${R}/tmp/pi-bluetooth/LICENCE.broadcom_bcm43xx" https://aur.archlinux.org/cgit/aur.git/plain/LICENCE.broadcom_bcm43xx?h=pi-bluetooth
-    as_nobody wget -q -O "${R}/tmp/pi-bluetooth/BCM43430A1.hcd" https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM43430A1.hcd
+    wget -q -O "${R}/tmp/pi-bluetooth/LICENCE.broadcom_bcm43xx" https://aur.archlinux.org/cgit/aur.git/plain/LICENCE.broadcom_bcm43xx?h=pi-bluetooth
+    wget -q -O "${R}/tmp/pi-bluetooth/BCM43430A1.hcd" https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM43430A1.hcd
 
     # Set permissions
     chown -R root:root "${R}/tmp/pi-bluetooth"

--- a/bootstrap.d/15-rpi-config.sh
+++ b/bootstrap.d/15-rpi-config.sh
@@ -120,7 +120,7 @@ if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
     temp_dir=$(as_nobody mktemp -d)
 
     # Fetch Bluetooth sources
-    as_nobody git -C "${temp_dir}" clone "${BLUETOOTH_URL}"
+    git -C "${temp_dir}" clone "${BLUETOOTH_URL}"
 
     # Copy downloaded sources
     mv "${temp_dir}/pi-bluetooth" "${R}/tmp/"

--- a/bootstrap.d/15-rpi-config.sh
+++ b/bootstrap.d/15-rpi-config.sh
@@ -112,7 +112,7 @@ if [ "$ENABLE_TURBO" = true ] ; then
   echo "boot_delay=1" >> "${BOOT_DIR}/config.txt"
 fi
 
-if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
+if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] || [ "$RPI_MODEL" = 4 ]; then
 
   # Bluetooth enabled
   if [ "$ENABLE_BLUETOOTH" = true ] ; then

--- a/bootstrap.d/20-networking.sh
+++ b/bootstrap.d/20-networking.sh
@@ -106,7 +106,7 @@ if [ "$ENABLE_WIRELESS" = true ] ; then
   temp_dir=$(as_nobody mktemp -d)
 
   # Fetch firmware binary blob for RPI3B+
-  if [ "$RPI_MODEL" = 3P ] ; then
+  if [ "$RPI_MODEL" = 3P ] || [ "$RPI_MODEL" = 4 ] ; then
     # Fetch firmware binary blob for RPi3P
     as_nobody wget -q -O "${temp_dir}/brcmfmac43455-sdio.bin" "${WLAN_FIRMWARE_URL}/brcmfmac43455-sdio.bin"
     as_nobody wget -q -O "${temp_dir}/brcmfmac43455-sdio.txt" "${WLAN_FIRMWARE_URL}/brcmfmac43455-sdio.txt"

--- a/bootstrap.d/43-videocore.sh
+++ b/bootstrap.d/43-videocore.sh
@@ -34,11 +34,11 @@ if [ "$ENABLE_VIDEOCORE" = true ] ; then
   cd "${R}"/tmp/userland/build
 
   if [ "$RELEASE_ARCH" = "arm64" ] ; then
-  cmake -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_BUILD_TYPE=release -DARM64=ON -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_ASM_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -U_FORTIFY_SOURCE" -DCMAKE_ASM_FLAGS="${CMAKE_ASM_FLAGS} -c" -DVIDEOCORE_BUILD_DIR="${R}" "${R}/tmp/userland"
+  cmake -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_BUILD_TYPE=release -DCMAKE_TOOLCHAIN_FILE="${R}"/tmp/userland/makefiles/cmake/toolchains/aarch64-linux-gnu.cmake -DARM64=ON -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_ASM_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -U_FORTIFY_SOURCE" -DCMAKE_ASM_FLAGS="${CMAKE_ASM_FLAGS} -c" -DVIDEOCORE_BUILD_DIR="${R}" "${R}/tmp/userland"
   fi
 
   if [ "$RELEASE_ARCH" = "armel" ] ; then
-  cmake -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=arm-linux-gnueabi-gcc -DCMAKE_CXX_COMPILER=arm-linux-gnueabi-g++ -DCMAKE_ASM_COMPILER=arm-linux-gnueabi-gcc -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -U_FORTIFY_SOURCE" -DCMAKE_ASM_FLAGS="${CMAKE_ASM_FLAGS} -c" -DCMAKE_SYSTEM_PROCESSOR="arm" -DVIDEOCORE_BUILD_DIR="${R}" "${R}/tmp/userland"
+  cmake -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_BUILD_TYPE=release -DCMAKE_TOOLCHAIN_FILE="${R}"/tmp/userland/makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake -DCMAKE_C_COMPILER=arm-linux-gnueabi-gcc -DCMAKE_CXX_COMPILER=arm-linux-gnueabi-g++ -DCMAKE_ASM_COMPILER=arm-linux-gnueabi-gcc -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -U_FORTIFY_SOURCE" -DCMAKE_ASM_FLAGS="${CMAKE_ASM_FLAGS} -c" -DCMAKE_SYSTEM_PROCESSOR="arm" -DVIDEOCORE_BUILD_DIR="${R}" "${R}/tmp/userland"
   fi
 
   if [ "$RELEASE_ARCH" = "armhf" ] ; then

--- a/bootstrap.d/44-nexmon_monitor_patch.sh
+++ b/bootstrap.d/44-nexmon_monitor_patch.sh
@@ -74,7 +74,7 @@ if [ "$ENABLE_NEXMON" = true ] && [ "$ENABLE_WIRELESS" = true ]; then
     cp -f "${NEXMON_ROOT}"/patches/bcm43430a1/7_45_41_46/nexmon/brcmfmac43430-sdio.bin "${WLAN_FIRMWARE_DIR}"/brcmfmac43430-sdio.bin
   fi
   
-  if [ "$RPI_MODEL" = 3P ] ; then
+  if [ "$RPI_MODEL" = 3P ] || [ "$RPI_MODEL" = 4 ] ; then
     cd "${NEXMON_ROOT}"/patches/bcm43455c0/7_45_154/nexmon || exit
 	sed -i -e 's/all:.*/all: $(RAM_FILE)/g' ${NEXMON_ROOT}/patches/bcm43455c0/7_45_154/nexmon/Makefile
     make clean

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -470,7 +470,7 @@ if [ -n "$MISSING_PACKAGES" ] ; then
   [ "$confirm" != "y" ] && exit 1
 
   # Make sure all missing required packages are installed
-  apt-get -qq -y install `echo "${MISSING_PACKAGES}" | sed "s/ //"`
+  apt-get update && apt-get -qq -y install `echo "${MISSING_PACKAGES}" | sed "s/ //"`
 fi
 
 # Check if ./bootstrap.d directory exists


### PR DESCRIPTION
https://github.com/drtyhlpr/rpi23-gen-image/issues/203
the removale before `git clone` is discussable, as it is consistenly used in the whole script, always ignoring the warning
https://github.com/drtyhlpr/rpi23-gen-image/issues/196
copying vexpress arm32 version to arm64 works just fine
`/root/rpi23-gen-image/images/bullseye/qemu/2019-10-22-arm64-CURRENT-rpi3P-bullseye-arm64.qcow2 (16G) : successfully created`
