### PR TITLE
PATCHES for:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # rpi23-gen-image
 ## Introduction
-`rpi23-gen-image.sh` is an advanced Debian Linux bootstrapping shell script for generating Debian OS images for all Raspberry Pi computers. The script at this time supports the bootstrapping of the Debian (armhf/armel) releases `stretch` and `buster`. Raspberry Pi 0/1/2/3 images are generated for 32-bit mode only. Raspberry Pi 3 supports 64-bit images that can be generated using custom configuration parameters (```templates/rpi3-stretch-arm64-4.14.y```).
+`rpi23-gen-image.sh` is an advanced Debian Linux bootstrapping shell script for generating Debian OS images for all Raspberry Pi computers. The script at this time supports the bootstrapping of the Debian (armhf/armel) releases `stretch` and `buster`. Raspberry Pi 0/1/2/3/4 images are generated for 32-bit mode only. Raspberry Pi 3 supports 64-bit images that can be generated using custom configuration parameters (```templates/rpi3-stretch-arm64-4.14.y```).
 
 ## Build dependencies
 The following list of Debian packages must be installed on the build system because they are essentially required for the bootstrapping process. The script will check if all required packages are installed and missing packages will be installed automatically if confirmed by the user.
 
   ```debootstrap debian-archive-keyring qemu-user-static binfmt-support dosfstools rsync bmap-tools whois git bc psmisc dbus sudo```
 
-It is recommended to configure the `rpi23-gen-image.sh` script to build and install the latest Raspberry Pi Linux kernel. For the Raspberry 3 this is mandatory. Kernel compilation and linking will be performed on the build system using an ARM (armhf/armel) cross-compiler toolchain.
+It is recommended to configure the `rpi23-gen-image.sh` script to build and install the latest Raspberry Pi Linux kernel. For the Raspberry 3 this is mandatory. Kernel compilation and linking will be performed on the build system using an ARM (armhf/armel/aarch64) cross-compiler toolchain.
 
 The script has been tested using the default `crossbuild-essential-armhf` and `crossbuild-essential-armel` toolchain meta packages on Debian Linux `stretch` build systems. Please check the [Debian CrossToolchains Wiki](https://wiki.debian.org/CrossToolchains) for further information.
 
@@ -61,7 +61,7 @@ A comma-separated list of additional packages to be installed by apt after boots
 
 #### General system settings:
 ##### `SET_ARCH`=32
-Set Architecture to default 32bit. If you want to compile 64-bit (RPI3 or RPI3+) set it to `64`. This option will set every needed cross-compiler or board specific option for a successful build.
+Set Architecture to default 32bit. If you want to compile 64-bit (RPI3/RPI3+/RPI4) set it to `64`. This option will set every needed cross-compiler or board specific option for a successful build.
 
 ##### `RPI_MODEL`=2
 Specify the target Raspberry Pi hardware model. The script at this time supports the following Raspberry Pi models:
@@ -71,6 +71,7 @@ Specify the target Raspberry Pi hardware model. The script at this time supports
 - `2`  = Raspberry Pi 2 model B
 - `3`  = Raspberry Pi 3 model B
 - `3P` = Raspberry Pi 3 model B+
+- `4`  = Raspberry Pi 4 model B
 
 ##### `RELEASE`="buster"
 Set the desired Debian release name. The script at this time supports the bootstrapping of the Debian releases `stretch` and `buster`.
@@ -230,6 +231,7 @@ Reduce the disk space usage by deleting packages and files. See `REDUCE_*` param
 
 ##### `ENABLE_UBOOT`=false
 Replace the default RPi 0/1/2/3 second stage bootloader (bootcode.bin) with [U-Boot bootloader](https://git.denx.de/?p=u-boot.git;a=summary). U-Boot can boot images via the network using the BOOTP/TFTP protocol.
+RPI4 needs tbd
 
 ##### `UBOOTSRC_DIR`=""
 Path to a directory (`u-boot`) of [U-Boot bootloader sources](https://git.denx.de/?p=u-boot.git;a=summary) that will be copied, configured, build and installed inside the chroot.
@@ -313,7 +315,11 @@ Add SSH (v2) public key(s) from specified file to `authorized_keys` file to enab
 
 #### Kernel compilation:
 ##### `BUILD_KERNEL`=true
-Build and install the latest RPi 0/1/2/3 Linux kernel. Currently only the default RPi 0/1/2/3 kernel configuration is used.
+Build and install the latest RPi 0/1/2/3/4 Linux kernel. The default RPi 0/1/2/3/ kernel configuration is used most of the time. 
+ENABLE_NEXMON - Changes Kernel Source to [https://github.com/Re4son/](Kali Linux Kernel)
+Precompiled 32bit kernel for RPI0/1/2/3 by [https://github.com/hypriot/](hypriot)
+Precompiled 64bit kernel for RPI3/4 by [https://github.com/sakaki-/](sakaki)
+
 
 ##### `CROSS_COMPILE`="arm-linux-gnueabihf-"
 This sets the cross-compile environment for the compiler.
@@ -390,6 +396,18 @@ Allow attaching eBPF programs to a cgroup using the bpf syscall (CONFIG_BPF_SYSC
 ##### `KERNEL_SECURITY`=false
 Enables Apparmor, integrity subsystem, auditing.
 
+##### `KERNEL_BTRFS`="false"
+enable btrfs kernel support
+
+##### `KERNEL_POEHAT`="false"
+enable Enable RPI POE HAT fan kernel support
+
+##### `KERNEL_NSPAWN`="false"
+Enable per-interface network priority control - for systemd-nspawn
+
+##### `KERNEL_DHKEY`="true"
+Diffie-Hellman operations on retained keys - required for >keyutils-1.6
+
 ---
 
 #### Reduce disk usage:
@@ -431,8 +449,11 @@ Set password of the encrypted root partition. This parameter is mandatory if `EN
 ##### `CRYPTFS_MAPPING`="secure"
 Set name of dm-crypt managed device-mapper mapping.
 
-##### `CRYPTFS_CIPHER`="aes-xts-plain64:sha512"
+##### `CRYPTFS_CIPHER`="aes-xts-plain64"
 Set cipher specification string. `aes-xts*` ciphers are strongly recommended.
+
+##### `CRYPTFS_HASH`=sha512
+Hash function and size to be used
 
 ##### `CRYPTFS_XTSKEYSIZE`=512
 Sets key size in bits. The argument has to be a multiple of 8.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ Support for halt,init,poweroff,reboot,runlevel,shutdown,telinit commands
 ---
 
 #### Advanced system features:
+##### `ENABLE_KEYGEN`=false
+Recover your lost codec license
+
 ##### `ENABLE_SYSTEMDSWAP`=false
 Enables [Systemd-swap service](https://github.com/Nefelim4ag/systemd-swap). Usefull if `KERNEL_ZSWAP` is enabled.
 

--- a/bootstrap.d/11-apt.sh
+++ b/bootstrap.d/11-apt.sh
@@ -16,9 +16,15 @@ install_readonly files/apt/sources.list "${ETC_DIR}/apt/sources.list"
 
 # Use specified APT server and release
 sed -i "s/\/ftp.debian.org\//\/${APT_SERVER}\//" "${ETC_DIR}/apt/sources.list"
+
+#Fix for changing path for security updates in testing/bullseye
 if [ "$RELEASE" = "testing" ] ; then
 sed -i "s,stretch\\/updates,testing-security," "${ETC_DIR}/apt/sources.list"
-else
+sed -i "s/ stretch/ ${RELEASE}/" "${ETC_DIR}/apt/sources.list"
+fi
+
+if [ -z "$RELEASE" ] ; then
+# Change release in sources list
 sed -i "s/ stretch/ ${RELEASE}/" "${ETC_DIR}/apt/sources.list"
 fi
 

--- a/bootstrap.d/11-apt.sh
+++ b/bootstrap.d/11-apt.sh
@@ -16,7 +16,7 @@ install_readonly files/apt/sources.list "${ETC_DIR}/apt/sources.list"
 
 # Use specified APT server and release
 sed -i "s/\/ftp.debian.org\//\/${APT_SERVER}\//" "${ETC_DIR}/apt/sources.list"
-if [ "$RELEASE" = "bullseye" ] || [ "$RELEASE" = "testing" ] ; then
+if [ "$RELEASE" = "testing" ] ; then
 sed -i "s,stretch\\/updates,testing-security," "${ETC_DIR}/apt/sources.list"
 else
 sed -i "s/ stretch/ ${RELEASE}/" "${ETC_DIR}/apt/sources.list"

--- a/bootstrap.d/11-apt.sh
+++ b/bootstrap.d/11-apt.sh
@@ -16,7 +16,11 @@ install_readonly files/apt/sources.list "${ETC_DIR}/apt/sources.list"
 
 # Use specified APT server and release
 sed -i "s/\/ftp.debian.org\//\/${APT_SERVER}\//" "${ETC_DIR}/apt/sources.list"
+if [ "$RELEASE" = "bullseye" ] || [ "$RELEASE" = "testing" ] ; then
+sed -i "s,stretch\\/updates,testing-security," "${ETC_DIR}/apt/sources.list"
+else
 sed -i "s/ stretch/ ${RELEASE}/" "${ETC_DIR}/apt/sources.list"
+fi
 
 # Upgrade package index and update all installed packages and changed dependencies
 chroot_exec apt-get -qq -y update

--- a/bootstrap.d/13-kernel.sh
+++ b/bootstrap.d/13-kernel.sh
@@ -52,6 +52,11 @@ if [ "$BUILD_KERNEL" = true ] ; then
   if [ "$KERNEL_THREADS" = "1" ] && [ -r /proc/cpuinfo ] ; then
     KERNEL_THREADS=$(grep -c processor /proc/cpuinfo)
   fi
+  
+  #Copy 32bit config to 64bit
+  if [ "$ENABLE_QEMU" = true ] && [ "$KERNEL_ARCH" = arm64 ]; then
+  cp "${KERNEL_DIR}"/arch/arm/configs/vexpress_defconfig "${KERNEL_DIR}"/arch/arm64/configs/
+  fi
 
   # Configure and build kernel
   if [ "$KERNELSRC_PREBUILT" = false ] ; then
@@ -99,6 +104,8 @@ if [ "$BUILD_KERNEL" = true ] ; then
       cd "${KERNEL_DIR}" || exit
 	  
 	  if [ "$KERNEL_ARCH" = arm64 ] ; then
+	  if [ "$KERNEL_ARCH" = arm64 ] && [ "$ENABLE_QEMU" = false ]; then
+	    # Mask this temporarily during switch to rpi-4.19.y
 	    #Fix SD_DRIVER upstream and downstream mess in 64bit RPIdeb_config
 	    # use correct driver MMC_BCM2835_MMC instead of MMC_BCM2835_SDHOST - see https://www.raspberrypi.org/forums/viewtopic.php?t=210225
 	    set_kernel_config CONFIG_MMC_BCM2835 n
@@ -118,12 +125,233 @@ if [ "$BUILD_KERNEL" = true ] ; then
         set_kernel_config CONFIG_Z3FOLD y
         set_kernel_config CONFIG_ZSMALLOC y
         set_kernel_config CONFIG_PGTABLE_MAPPING y
-		set_kernel_config CONFIG_LZO_COMPRESS y
-
+	    set_kernel_config CONFIG_LZO_COMPRESS y
 	  fi
+	  
+	  if [ RPI_MODEL = 4 ] ; then
+	  # Following are set in current 32-bit LPAE kernel
+	    set_kernel_config CONFIG_CGROUP_PIDS y
+	    set_kernel_config CONFIG_NET_IPVTI m
+	    set_kernel_config CONFIG_NF_TABLES_SET m
+	    set_kernel_config CONFIG_NF_TABLES_INET y
+	    set_kernel_config CONFIG_NF_TABLES_NETDEV y
+	    set_kernel_config CONFIG_NF_FLOW_TABLE m
+	    set_kernel_config CONFIG_NFT_FLOW_OFFLOAD m
+	    set_kernel_config CONFIG_NFT_CONNLIMIT m
+	    set_kernel_config CONFIG_NFT_TUNNEL m
+	    set_kernel_config CONFIG_NFT_OBJREF m
+	    set_kernel_config CONFIG_NFT_FIB_IPV4 m
+	    set_kernel_config CONFIG_NFT_FIB_IPV6 m
+	    set_kernel_config CONFIG_NFT_FIB_INET m
+	    set_kernel_config CONFIG_NFT_SOCKET m
+	    set_kernel_config CONFIG_NFT_OSF m
+	    set_kernel_config CONFIG_NFT_TPROXY m
+	    set_kernel_config CONFIG_NF_DUP_NETDEV m
+	    set_kernel_config CONFIG_NFT_DUP_NETDEV m
+	    set_kernel_config CONFIG_NFT_FWD_NETDEV m
+	    set_kernel_config CONFIG_NFT_FIB_NETDEV m
+	    set_kernel_config CONFIG_NF_FLOW_TABLE_INET m
+	    set_kernel_config CONFIG_NF_FLOW_TABLE m
+	    set_kernel_config CONFIG_NETFILTER_XT_MATCH_SOCKET m
+	    set_kernel_config CONFIG_NFT_CHAIN_ROUTE_IPV6 m
+	    set_kernel_config CONFIG_NFT_CHAIN_NAT_IPV6 m
+	    set_kernel_config CONFIG_NFT_MASQ_IPV6 m
+	    set_kernel_config CONFIG_NFT_REDIR_IPV6 m
+	    set_kernel_config CONFIG_NFT_REJECT_IPV6 m
+	    set_kernel_config CONFIG_NFT_DUP_IPV6 m
+	    set_kernel_config CONFIG_NFT_FIB_IPV6 m
+	    set_kernel_config CONFIG_NF_FLOW_TABLE_IPV6 m
+	    set_kernel_config CONFIG_NF_TABLES_BRIDGE m
+	    set_kernel_config CONFIG_NFT_BRIDGE_REJECT m
+	    set_kernel_config CONFIG_NF_LOG_BRIDGE m
+	    set_kernel_config CONFIG_MT76_CORE m
+	    set_kernel_config CONFIG_MT76_LEDS m
+	    set_kernel_config CONFIG_MT76_USB m
+	    set_kernel_config CONFIG_MT76x2_COMMON m
+	    set_kernel_config CONFIG_MT76x0U m
+	    set_kernel_config CONFIG_MT76x2U m
+	    set_kernel_config CONFIG_TOUCHSCREEN_ILI210X m
+	    set_kernel_config CONFIG_BCM_VC_SM m
+	    set_kernel_config CONFIG_BCM2835_SMI_DEV m
+	    set_kernel_config CONFIG_RPIVID_MEM m
+	    set_kernel_config CONFIG_HW_RANDOM_BCM2835 y
+	    set_kernel_config CONFIG_TCG_TPM m
+	    set_kernel_config CONFIG_HW_RANDOM_TPM y
+	    set_kernel_config CONFIG_TCG_TIS m
+	    set_kernel_config CONFIG_TCG_TIS_SPI m
+	    set_kernel_config CONFIG_I2C_MUX m
+	    set_kernel_config CONFIG_I2C_MUX_GPMUX m
+	    set_kernel_config CONFIG_I2C_MUX_PCA954x m
+	    set_kernel_config CONFIG_SPI_GPIO m
+	    set_kernel_config CONFIG_BATTERY_MAX17040 m
+	    set_kernel_config CONFIG_SENSORS_GPIO_FAN m
+	    set_kernel_config CONFIG_SENSORS_RASPBERRYPI_HWMON m
+	    set_kernel_config CONFIG_BCM2835_THERMAL y
+	    set_kernel_config CONFIG_RC_CORE y
+	    set_kernel_config CONFIG_RC_MAP y
+	    set_kernel_config CONFIG_LIRC y
+	    set_kernel_config CONFIG_RC_DECODERS y
+	    set_kernel_config CONFIG_IR_NEC_DECODER m
+	    set_kernel_config CONFIG_IR_RC5_DECODER m
+	    set_kernel_config CONFIG_IR_RC6_DECODER m
+	    set_kernel_config CONFIG_IR_JVC_DECODER m
+	    set_kernel_config CONFIG_IR_SONY_DECODER m
+	    set_kernel_config CONFIG_IR_SANYO_DECODER m
+	    set_kernel_config CONFIG_IR_SHARP_DECODER m
+	    set_kernel_config CONFIG_IR_MCE_KBD_DECODER m
+	    set_kernel_config CONFIG_IR_XMP_DECODER m
+	    set_kernel_config CONFIG_IR_IMON_DECODER m
+	    set_kernel_config CONFIG_RC_DEVICES y
+	    set_kernel_config CONFIG_RC_ATI_REMOTE m
+	    set_kernel_config CONFIG_IR_IMON m
+	    set_kernel_config CONFIG_IR_MCEUSB m
+	    set_kernel_config CONFIG_IR_REDRAT3 m
+	    set_kernel_config CONFIG_IR_STREAMZAP m
+	    set_kernel_config CONFIG_IR_IGUANA m
+	    set_kernel_config CONFIG_IR_TTUSBIR m
+	    set_kernel_config CONFIG_RC_LOOPBACK m
+	    set_kernel_config CONFIG_IR_GPIO_CIR m
+	    set_kernel_config CONFIG_IR_GPIO_TX m
+	    set_kernel_config CONFIG_IR_PWM_TX m
+	    set_kernel_config CONFIG_VIDEO_V4L2_SUBDEV_API y
+	    set_kernel_config CONFIG_VIDEO_AU0828_RC y
+	    set_kernel_config CONFIG_VIDEO_CX231XX m
+	    set_kernel_config CONFIG_VIDEO_CX231XX_RC y
+	    set_kernel_config CONFIG_VIDEO_CX231XX_ALSA m
+	    set_kernel_config CONFIG_VIDEO_CX231XX_DVB m
+	    set_kernel_config CONFIG_VIDEO_TM6000 m
+	    set_kernel_config CONFIG_VIDEO_TM6000_ALSA m
+	    set_kernel_config CONFIG_VIDEO_TM6000_DVB m
+	    set_kernel_config CONFIG_DVB_USB m
+	    set_kernel_config CONFIG_DVB_USB_DIB3000MC m
+	    set_kernel_config CONFIG_DVB_USB_A800 m
+	    set_kernel_config CONFIG_DVB_USB_DIBUSB_MB m
+	    set_kernel_config CONFIG_DVB_USB_DIBUSB_MB_FAULTY y
+	    set_kernel_config CONFIG_DVB_USB_DIBUSB_MC m
+	    set_kernel_config CONFIG_DVB_USB_DIB0700 m
+	    set_kernel_config CONFIG_DVB_USB_UMT_010 m
+	    set_kernel_config CONFIG_DVB_USB_CXUSB m
+	    set_kernel_config CONFIG_DVB_USB_M920X m
+	    set_kernel_config CONFIG_DVB_USB_DIGITV m
+	    set_kernel_config CONFIG_DVB_USB_VP7045 m
+	    set_kernel_config CONFIG_DVB_USB_VP702X m
+	    set_kernel_config CONFIG_DVB_USB_GP8PSK m
+	    set_kernel_config CONFIG_DVB_USB_NOVA_T_USB2 m
+	    set_kernel_config CONFIG_DVB_USB_TTUSB2 m
+	    set_kernel_config CONFIG_DVB_USB_DTT200U m
+	    set_kernel_config CONFIG_DVB_USB_OPERA1 m
+	    set_kernel_config CONFIG_DVB_USB_AF9005 m
+	    set_kernel_config CONFIG_DVB_USB_AF9005_REMOTE m
+	    set_kernel_config CONFIG_DVB_USB_PCTV452E m
+	    set_kernel_config CONFIG_DVB_USB_DW2102 m
+	    set_kernel_config CONFIG_DVB_USB_CINERGY_T2 m
+	    set_kernel_config CONFIG_DVB_USB_DTV5100 m
+	    set_kernel_config CONFIG_DVB_USB_AZ6027 m
+	    set_kernel_config CONFIG_DVB_USB_TECHNISAT_USB2 m
+	    set_kernel_config CONFIG_DVB_USB_AF9015 m
+	    set_kernel_config CONFIG_DVB_USB_LME2510 m
+	    set_kernel_config CONFIG_DVB_USB_RTL28XXU m
+	    set_kernel_config CONFIG_VIDEO_EM28XX_RC m
+	    set_kernel_config CONFIG_SMS_SIANO_RC m
+	    set_kernel_config CONFIG_VIDEO_IR_I2C m
+	    set_kernel_config CONFIG_VIDEO_ADV7180 m
+	    set_kernel_config CONFIG_VIDEO_TC358743 m
+	    set_kernel_config CONFIG_VIDEO_OV5647 m
+	    set_kernel_config CONFIG_DVB_M88DS3103 m
+	    set_kernel_config CONFIG_DVB_AF9013 m
+	    set_kernel_config CONFIG_DVB_RTL2830 m
+	    set_kernel_config CONFIG_DVB_RTL2832 m
+	    set_kernel_config CONFIG_DVB_SI2168 m
+	    set_kernel_config CONFIG_DVB_GP8PSK_FE m
+	    set_kernel_config CONFIG_DVB_USB m
+	    set_kernel_config CONFIG_DVB_LGDT3306A m
+	    set_kernel_config CONFIG_FB_SIMPLE y
+	    set_kernel_config CONFIG_SND_BCM2708_SOC_IQAUDIO_CODEC m
+	    set_kernel_config CONFIG_SND_BCM2708_SOC_I_SABRE_Q2M m
+	    set_kernel_config CONFIG_SND_AUDIOSENSE_PI m
+	    set_kernel_config CONFIG_SND_SOC_AD193X m
+	    set_kernel_config CONFIG_SND_SOC_AD193X_SPI m
+	    set_kernel_config CONFIG_SND_SOC_AD193X_I2C m
+	    set_kernel_config CONFIG_SND_SOC_CS4265 m
+	    set_kernel_config CONFIG_SND_SOC_DA7213 m
+	    set_kernel_config CONFIG_SND_SOC_ICS43432 m
+	    set_kernel_config CONFIG_SND_SOC_TLV320AIC32X4 m
+	    set_kernel_config CONFIG_SND_SOC_TLV320AIC32X4_I2C m
+	    set_kernel_config CONFIG_SND_SOC_I_SABRE_CODEC m
+	    set_kernel_config CONFIG_HID_BIGBEN_FF m
+	    #set_kernel_config CONFIG_USB_XHCI_PLATFORM y
+	    set_kernel_config CONFIG_USB_TMC m
+	    set_kernel_config CONFIG_USB_UAS y
+	    set_kernel_config CONFIG_USBIP_VUDC m
+	    set_kernel_config CONFIG_USB_CONFIGFS m
+	    set_kernel_config CONFIG_USB_CONFIGFS_SERIAL y
+	    set_kernel_config CONFIG_USB_CONFIGFS_ACM y
+	    set_kernel_config CONFIG_USB_CONFIGFS_OBEX y
+	    set_kernel_config CONFIG_USB_CONFIGFS_NCM y
+	    set_kernel_config CONFIG_USB_CONFIGFS_ECM y
+	    set_kernel_config CONFIG_USB_CONFIGFS_ECM_SUBSET y
+	    set_kernel_config CONFIG_USB_CONFIGFS_RNDIS y
+	    set_kernel_config CONFIG_USB_CONFIGFS_EEM y
+	    set_kernel_config CONFIG_USB_CONFIGFS_MASS_STORAGE y
+	    set_kernel_config CONFIG_USB_CONFIGFS_F_LB_SS y
+	    set_kernel_config CONFIG_USB_CONFIGFS_F_FS y
+	    set_kernel_config CONFIG_USB_CONFIGFS_F_UAC1 y
+	    set_kernel_config CONFIG_USB_CONFIGFS_F_UAC2 y
+	    set_kernel_config CONFIG_USB_CONFIGFS_F_MIDI y
+	    set_kernel_config CONFIG_USB_CONFIGFS_F_HID y
+	    set_kernel_config CONFIG_USB_CONFIGFS_F_UVC y
+	    set_kernel_config CONFIG_USB_CONFIGFS_F_PRINTER y
+	    set_kernel_config CONFIG_LEDS_PCA963X m
+	    set_kernel_config CONFIG_LEDS_IS31FL32XX m
+	    set_kernel_config CONFIG_LEDS_TRIGGER_NETDEV m
+	    set_kernel_config CONFIG_RTC_DRV_RV3028 m
+	    set_kernel_config CONFIG_AUXDISPLAY y
+	    set_kernel_config CONFIG_HD44780 m
+	    set_kernel_config CONFIG_FB_TFT_SH1106 m
+	    set_kernel_config CONFIG_VIDEO_CODEC_BCM2835 m
+	    set_kernel_config CONFIG_BCM2835_POWER y
+	    set_kernel_config CONFIG_INV_MPU6050_IIO m
+	    set_kernel_config CONFIG_INV_MPU6050_I2C m
+	    set_kernel_config CONFIG_SECURITYFS y
+
+	    # Safer to build this in
+	    set_kernel_config CONFIG_BINFMT_MISC y
+
+	    # pulseaudio wants a buffer of at least this size
+	    set_kernel_config CONFIG_SND_HDA_PREALLOC_SIZE 2048
+
+	    # PR#3063: enable 3D acceleration with 64-bit kernel on RPi4
+	    # set the appropriate kernel configs unlocked by this PR
+	    set_kernel_config CONFIG_ARCH_BCM y
+	    set_kernel_config CONFIG_ARCH_BCM2835 y
+	    set_kernel_config CONFIG_DRM_V3D m
+	    set_kernel_config CONFIG_DRM_VC4 m
+	    set_kernel_config CONFIG_DRM_VC4_HDMI_CEC y
+
+	    # PR#3144: add arm64 pcie bounce buffers; enables 4GiB on RPi4
+	    # required by PR#3144; should already be applied, but just to be safe
+	    set_kernel_config CONFIG_PCIE_BRCMSTB y
+	    set_kernel_config CONFIG_BCM2835_MMC y
+
+	    # Snap needs squashfs. The ubuntu eoan-preinstalled-server image at 
+	    # http://cdimage.ubuntu.com/ubuntu-server/daily-preinstalled/current/ uses snap
+	    # during cloud-init setup at first boot. Without this the login accounts are not
+	    # created and the user can not login.
+	    set_kernel_config CONFIG_SQUASHFS y
+
+	    # Ceph support for Block Device (RBD) and Filesystem (FS)
+	    # https://docs.ceph.com/docs/master/
+	    set_kernel_config CONFIG_CEPH_LIB m
+	    set_kernel_config CONFIG_CEPH_LIB_USE_DNS_RESOLVER y
+	    set_kernel_config CONFIG_CEPH_FS m
+	    set_kernel_config CONFIG_CEPH_FSCACHE y
+	    set_kernel_config CONFIG_CEPH_FS_POSIX_ACL y
+	    set_kernel_config CONFIG_BLK_DEV_RBD m
 
       # enable basic KVM support; see https://www.raspberrypi.org/forums/viewtopic.php?f=63&t=210546&start=25#p1300453
-	  if [ "$KERNEL_VIRT" = true ] && { [ "$RPI_MODEL" = 2 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; } ; then
+	  if [ "$KERNEL_VIRT" = true ] && { [ "$RPI_MODEL" = 2 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] || [ "$RPI_MODEL" = 4 ]; } ; then
+		set_kernel_config CONFIG_HAVE_KVM y
+		set_kernel_config CONFIG_HIGH_RES_TIMERS y
 		set_kernel_config CONFIG_HAVE_KVM_IRQCHIP y
         set_kernel_config CONFIG_HAVE_KVM_ARCH_TLB_FLUSH_ALL y
         set_kernel_config CONFIG_HAVE_KVM_CPU_RELAX_INTERCEPT y
@@ -138,11 +366,13 @@ if [ "$BUILD_KERNEL" = true ] ; then
         set_kernel_config CONFIG_KVM_GENERIC_DIRTYLOG_READ_PROTECT y
         set_kernel_config CONFIG_KVM_MMIO y
         set_kernel_config CONFIG_KVM_VFIO y
+		set_kernel_config CONFIG_KVM_MMU_AUDIT y
         set_kernel_config CONFIG_VHOST m
         set_kernel_config CONFIG_VHOST_CROSS_ENDIAN_LEGACY y
         set_kernel_config CONFIG_VHOST_NET m
         set_kernel_config CONFIG_VIRTUALIZATION y
-		
+		set_kernel_config CONFIG_SLAB_FREELIST_RANDOM=y
+		set_kernel_config CONFIG_SLAB_FREELIST_HARDENED=y
 		set_kernel_config CONFIG_MMU_NOTIFIER y
 		
 		# erratum
@@ -193,12 +423,6 @@ if [ "$BUILD_KERNEL" = true ] ; then
         set_kernel_config CONFIG_SECURITY_PATH y
         set_kernel_config CONFIG_SECURITY_YAMA n
 
-        # New Options
-        if [ "$KERNEL_NF" = true ] ; then
-          set_kernel_config CONFIG_IP_NF_SECURITY m
-          set_kernel_config CONFIG_NETLABEL y
-          set_kernel_config CONFIG_IP6_NF_SECURITY m
-        fi
         set_kernel_config CONFIG_SECURITY_SELINUX n
         set_kernel_config CONFIG_SECURITY_SMACK n
         set_kernel_config CONFIG_SECURITY_TOMOYO n
@@ -211,7 +435,6 @@ if [ "$BUILD_KERNEL" = true ] ; then
         set_kernel_config CONFIG_NFSD_V4_SECURITY_LABEL y
         set_kernel_config CONFIG_PKCS7_MESSAGE_PARSER y
         set_kernel_config CONFIG_SYSTEM_TRUSTED_KEYRING y
-        set_kernel_config CONFIG_SYSTEM_TRUSTED_KEYS y
         set_kernel_config CONFIG_SYSTEM_EXTRA_CERTIFICATE y
         set_kernel_config CONFIG_SECONDARY_TRUSTED_KEYRING y
         set_kernel_config CONFIG_IMA_KEYRINGS_PERMIT_SIGNED_BY_BUILTIN_OR_SECONDARY n
@@ -233,11 +456,13 @@ if [ "$BUILD_KERNEL" = true ] ; then
         set_kernel_config CONFIG_CRYPTO_AES_ARM64_NEON_BLK m
         set_kernel_config CONFIG_CRYPTO_CHACHA20_NEON m
         set_kernel_config CONFIG_CRYPTO_AES_ARM64_BS m
-		set_kernel_config SYSTEM_TRUSTED_KEYS
       fi
 
       # Netfilter kernel support See https://github.com/raspberrypi/linux/issues/2177#issuecomment-354647406
       if [ "$KERNEL_NF" = true ] ; then
+	    set_kernel_config CONFIG_IP_NF_SECURITY m
+        set_kernel_config CONFIG_NETLABEL y
+        set_kernel_config CONFIG_IP6_NF_SECURITY m
         set_kernel_config CONFIG_IP_NF_TARGET_SYNPROXY m
         set_kernel_config CONFIG_NETFILTER_XT_TARGET_AUDIT m
         set_kernel_config CONFIG_NETFILTER_XT_MATCH_CGROUP m
@@ -263,7 +488,6 @@ if [ "$BUILD_KERNEL" = true ] ; then
         set_kernel_config CONFIG_IP6_NF_NAT m
         set_kernel_config CONFIG_IP6_NF_TARGET_MASQUERADE m
         set_kernel_config CONFIG_IP6_NF_TARGET_NPT m
-        set_kernel_config CONFIG_IP_NF_SECURITY m
         set_kernel_config CONFIG_IP_SET_BITMAP_IPMAC m
         set_kernel_config CONFIG_IP_SET_BITMAP_PORT m
         set_kernel_config CONFIG_IP_SET_HASH_IP m
@@ -326,11 +550,11 @@ if [ "$BUILD_KERNEL" = true ] ; then
         set_kernel_config CONFIG_NF_LOG_IPV6 m
         set_kernel_config CONFIG_NF_NAT_IPV4 m
         set_kernel_config CONFIG_NF_NAT_IPV6 m
-        set_kernel_config CONFIG_NF_NAT_MASQUERADE_IPV4 m
-        set_kernel_config CONFIG_NF_NAT_MASQUERADE_IPV6 m
+        set_kernel_config CONFIG_NF_NAT_MASQUERADE_IPV4 y
+        set_kernel_config CONFIG_NF_NAT_MASQUERADE_IPV6 y
         set_kernel_config CONFIG_NF_NAT_PPTP m
         set_kernel_config CONFIG_NF_NAT_PROTO_GRE m
-        set_kernel_config CONFIG_NF_NAT_REDIRECT m
+        set_kernel_config CONFIG_NF_NAT_REDIRECT y
         set_kernel_config CONFIG_NF_NAT_SIP m
         set_kernel_config CONFIG_NF_NAT_SNMP_BASIC m
         set_kernel_config CONFIG_NF_NAT_TFTP m
@@ -340,17 +564,35 @@ if [ "$BUILD_KERNEL" = true ] ; then
         set_kernel_config CONFIG_NF_TABLES_ARP m
         set_kernel_config CONFIG_NF_TABLES_BRIDGE m
         set_kernel_config CONFIG_NF_TABLES_INET m
-        set_kernel_config CONFIG_NF_TABLES_IPV4 m
-        set_kernel_config CONFIG_NF_TABLES_IPV6 m
+        set_kernel_config CONFIG_NF_TABLES_IPV4 y
+        set_kernel_config CONFIG_NF_TABLES_IPV6 y
         set_kernel_config CONFIG_NF_TABLES_NETDEV m
+        set_kernel_config CONFIG_NF_TABLES_SET m
+        set_kernel_config CONFIG_NF_TABLES_INET y
+        set_kernel_config CONFIG_NF_TABLES_NETDEV y
+        set_kernel_config CONFIG_NFT_CONNLIMIT m
+        set_kernel_config CONFIG_NFT_TUNNEL m
+        set_kernel_config CONFIG_NFT_SOCKET m
+        set_kernel_config CONFIG_NFT_TPROXY m
+        set_kernel_config CONFIG_NF_FLOW_TABLE m
+        set_kernel_config CONFIG_NFT_FLOW_OFFLOAD m
+        set_kernel_config CONFIG_NF_FLOW_TABLE_INET m
+        set_kernel_config CONFIG_NF_TABLES_ARP y
+        set_kernel_config CONFIG_NF_FLOW_TABLE_IPV4 y
+        set_kernel_config CONFIG_NF_FLOW_TABLE_IPV6 y
+        set_kernel_config CONFIG_NF_TABLES_BRIDGE y
+        set_kernel_config CONFIG_NF_CT_NETLINK_TIMEOUT m
+        set_kernel_config CONFIG_NFT_OSF m
+	
       fi
 
 	  # Enables BPF syscall for systemd-journald see https://github.com/torvalds/linux/blob/master/init/Kconfig#L848 or https://groups.google.com/forum/#!topic/linux.gentoo.user/_2aSc_ztGpA
 	  if [ "$KERNEL_BPF" = true ] ; then
         set_kernel_config CONFIG_BPF_SYSCALL y
-		set_kernel_config CONFIG_BPF_EVENTS y
-		set_kernel_config CONFIG_BPF_STREAM_PARSER y
+	    set_kernel_config CONFIG_BPF_EVENTS y
+	    set_kernel_config CONFIG_BPF_STREAM_PARSER y
 	    set_kernel_config CONFIG_CGROUP_BPF y
+	    set_kernel_config CONFIG_XDP_SOCKETS y
 	  fi
 
 	  # KERNEL_DEFAULT_GOV was set by user 
@@ -537,20 +779,28 @@ if [ "$BUILD_KERNEL" = true ] ; then
   fi
 
 else # BUILD_KERNEL=false
-  if [ "$SET_ARCH" = 64 ] && { [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; } ; then
+  if [ "$SET_ARCH" = 64 ] ; then
+    if [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
+	  # Use Sakakis modified kernel if ZSWAP is active
+      if [ "$KERNEL_ZSWAP" = true ] || [ "$KERNEL_VIRT" = true ] || [ "$KERNEL_NF" = true ] || [ "$KERNEL_BPF" = true ] ; then
+	    RPI3_64_KERNEL_URL="${RPI3_64_BIS_KERNEL_URL}"
+	  fi
 
-	# Use Sakakis modified kernel if ZSWAP is active
-    if [ "$KERNEL_ZSWAP" = true ] || [ "$KERNEL_VIRT" = true ] || [ "$KERNEL_NF" = true ] || [ "$KERNEL_BPF" = true ] ; then
-	  RPI3_64_KERNEL_URL="${RPI3_64_BIS_KERNEL_URL}"
-	fi
+      # Create temporary directory for dl
+      temp_dir=$(as_nobody mktemp -d)
 
-    # Create temporary directory for dl
-    temp_dir=$(as_nobody mktemp -d)
+      # Fetch kernel dl
+      as_nobody wget -O "${temp_dir}"/kernel.tar.xz -c "$RPI3_64_KERNEL_URL" 
+    fi
+    if [ "$SET_ARCH" = 64 ] && [ "$RPI_MODEL" = 4 ] ; then
+      # Create temporary directory for dl
+      temp_dir=$(as_nobody mktemp -d)
 
-    # Fetch kernel dl
-    as_nobody wget -O "${temp_dir}"/kernel.tar.xz -c "$RPI3_64_KERNEL_URL" 
-
-    #extract download
+      # Fetch kernel dl
+      as_nobody wget -O "${temp_dir}"/kernel.tar.xz -c "$RPI4_64_KERNEL_URL" 
+    fi
+	
+	#extract download
     tar -xJf "${temp_dir}"/kernel.tar.xz -C "${temp_dir}"
 
     #move extracted kernel to /boot/firmware
@@ -566,15 +816,15 @@ else # BUILD_KERNEL=false
     chown -R root:root "${R}/lib/modules"
   fi
 
-  # Install Kernel from hypriot comptabile with all Raspberry PI
-  if [ "$SET_ARCH" = 32 ] ; then
+  # Install Kernel from hypriot comptabile with all Raspberry PI (dunno if its compatible with RPI4 - better compile your own kernel)
+  if [ "$SET_ARCH" = 32 ] && [ "$RPI_MODEL" != 4 ] ; then
     # Create temporary directory for dl
     temp_dir=$(as_nobody mktemp -d)
 
     # Fetch kernel
     as_nobody wget -O "${temp_dir}"/kernel.deb -c "$RPI_32_KERNEL_URL"
 
-    # Copy downloaded U-Boot sources
+    # Copy downloaded kernel package
     mv "${temp_dir}"/kernel.deb "${R}"/tmp/kernel.deb
 
     # Set permissions

--- a/bootstrap.d/13-kernel.sh
+++ b/bootstrap.d/13-kernel.sh
@@ -103,7 +103,30 @@ if [ "$BUILD_KERNEL" = true ] ; then
       #Switch to KERNELSRC_DIR so we can use set_kernel_config
       cd "${KERNEL_DIR}" || exit
 	  
-	  if [ "$KERNEL_ARCH" = arm64 ] ; then
+	  # Enable RPI POE HAT fan
+	  if [ "$KERNEL_POEHAT" = true ]; then
+	  set_kernel_config CONFIG_SENSORS_RPI_POE_FAN m
+	  fi
+
+	  # Enable per-interface network priority control
+	  # (for systemd-nspawn)
+	  if [ "$KERNEL_NSPAN" = true ]; then
+	  set_kernel_config CONFIG_CGROUP_NET_PRIO y
+	  fi
+	  
+	  # Compile in BTRFS
+	  if [ "$KERNEL_BTRFS" = true ]; then
+	  set_kernel_config CONFIG_BTRFS_FS y
+	  set_kernel_config CONFIG_BTRFS_FS_POSIX_ACL y
+	  set_kernel_config CONFIG_BTRFS_FS_REF_VERIFY y
+	  fi
+	  
+	  # Diffie-Hellman operations on retained keys
+	  # (required for >keyutils-1.6)
+	  if [ "$KERNEL_DHKEY" = true ]; then
+		set_kernel_config CONFIG_KEY_DH_OPERATIONS y
+	  fi 
+	  
 	  if [ "$KERNEL_ARCH" = arm64 ] && [ "$ENABLE_QEMU" = false ]; then
 	    # Mask this temporarily during switch to rpi-4.19.y
 	    #Fix SD_DRIVER upstream and downstream mess in 64bit RPIdeb_config

--- a/bootstrap.d/13-kernel.sh
+++ b/bootstrap.d/13-kernel.sh
@@ -128,7 +128,7 @@ if [ "$BUILD_KERNEL" = true ] ; then
 	    set_kernel_config CONFIG_LZO_COMPRESS y
 	  fi
 	  
-	  if [ RPI_MODEL = 4 ] ; then
+	  if [ "$RPI_MODEL" = 4 ] ; then
 	  # Following are set in current 32-bit LPAE kernel
 	    set_kernel_config CONFIG_CGROUP_PIDS y
 	    set_kernel_config CONFIG_NET_IPVTI m
@@ -347,6 +347,7 @@ if [ "$BUILD_KERNEL" = true ] ; then
 	    set_kernel_config CONFIG_CEPH_FSCACHE y
 	    set_kernel_config CONFIG_CEPH_FS_POSIX_ACL y
 	    set_kernel_config CONFIG_BLK_DEV_RBD m
+	  fi
 
       # enable basic KVM support; see https://www.raspberrypi.org/forums/viewtopic.php?f=63&t=210546&start=25#p1300453
 	  if [ "$KERNEL_VIRT" = true ] && { [ "$RPI_MODEL" = 2 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] || [ "$RPI_MODEL" = 4 ]; } ; then

--- a/bootstrap.d/13-kernel.sh
+++ b/bootstrap.d/13-kernel.sh
@@ -108,10 +108,10 @@ if [ "$BUILD_KERNEL" = true ] ; then
 	    # Mask this temporarily during switch to rpi-4.19.y
 	    #Fix SD_DRIVER upstream and downstream mess in 64bit RPIdeb_config
 	    # use correct driver MMC_BCM2835_MMC instead of MMC_BCM2835_SDHOST - see https://www.raspberrypi.org/forums/viewtopic.php?t=210225
-	    set_kernel_config CONFIG_MMC_BCM2835 n
-	    set_kernel_config CONFIG_MMC_SDHCI_IPROC n
-	    set_kernel_config CONFIG_USB_DWC2 n
-	    sed -i "s|depends on MMC_BCM2835_MMC && MMC_BCM2835_DMA|depends on MMC_BCM2835_MMC|" "${KERNEL_DIR}"/drivers/mmc/host/Kconfig
+	    #set_kernel_config CONFIG_MMC_BCM2835 n
+	    #set_kernel_config CONFIG_MMC_SDHCI_IPROC n
+	    #set_kernel_config CONFIG_USB_DWC2 n
+	    #sed -i "s|depends on MMC_BCM2835_MMC && MMC_BCM2835_DMA|depends on MMC_BCM2835_MMC|" "${KERNEL_DIR}"/drivers/mmc/host/Kconfig
 	  
 	    #VLAN got disabled without reason in arm64bit
 	    set_kernel_config CONFIG_IPVLAN m
@@ -600,10 +600,10 @@ if [ "$BUILD_KERNEL" = true ] ; then
 
 	    case "$KERNEL_DEFAULT_GOV" in
           performance)
-	        set_kernel_config CONFIG_CPU_FREQ_DEFAULT_GOV_PERFORMANCE y
+	            set_kernel_config CONFIG_CPU_FREQ_DEFAULT_GOV_PERFORMANCE y
             ;;
           userspace)
-            set_kernel_config CONFIG_CPU_FREQ_DEFAULT_GOV_USERSPACE y
+            	    set_kernel_config CONFIG_CPU_FREQ_DEFAULT_GOV_USERSPACE y
             ;;
           ondemand)
 		    set_kernel_config CONFIG_CPU_FREQ_DEFAULT_GOV_ONDEMAND y

--- a/bootstrap.d/14-fstab.sh
+++ b/bootstrap.d/14-fstab.sh
@@ -8,108 +8,112 @@
 # Install and setup fstab
 install_readonly files/mount/fstab "${ETC_DIR}/fstab"
 
-# Add usb/sda disk root partition to fstab
-if [ "$ENABLE_SPLITFS" = true ] && [ "$ENABLE_CRYPTFS" = false ] ; then
-  sed -i "s/mmcblk0p2/sda1/" "${ETC_DIR}/fstab"
-fi
-
-# Add encrypted root partition to fstab and crypttab
-if [ "$ENABLE_CRYPTFS" = true ] ; then
-  # Replace fstab root partition with encrypted partition mapping
-  sed -i "s/mmcblk0p2/mapper\/${CRYPTFS_MAPPING}/" "${ETC_DIR}/fstab"
-
-  # Add encrypted partition to crypttab and fstab
-  install_readonly files/mount/crypttab "${ETC_DIR}/crypttab"
-  echo "${CRYPTFS_MAPPING} /dev/mmcblk0p2 none luks,initramfs" >> "${ETC_DIR}/crypttab"
-
-  if [ "$ENABLE_SPLITFS" = true ] ; then
-    # Add usb/sda1 disk to crypttab
-    sed -i "s/mmcblk0p2/sda1/" "${ETC_DIR}/crypttab"
-  fi
-fi
-
-if [ "$ENABLE_USBBOOT" = true ] ; then
-  sed -i "s/mmcblk0p1/sda1/" "${ETC_DIR}/fstab"
-  sed -i "s/mmcblk0p2/sda2/" "${ETC_DIR}/fstab"
-
-  # Add usb/sda2 disk to crypttab
-  sed -i "s/mmcblk0p2/sda2/" "${ETC_DIR}/crypttab"
-fi
-
 # Generate initramfs file
 if [ "$ENABLE_INITRAMFS" = true ] ; then
   if [ "$ENABLE_CRYPTFS" = true ] ; then
+    
     # Include initramfs scripts to auto expand encrypted root partition
     if [ "$EXPANDROOT" = true ] ; then
       install_exec files/initramfs/expand_encrypted_rootfs "${ETC_DIR}/initramfs-tools/scripts/init-premount/expand_encrypted_rootfs"
       install_exec files/initramfs/expand-premount "${ETC_DIR}/initramfs-tools/scripts/local-premount/expand-premount"
       install_exec files/initramfs/expand-tools "${ETC_DIR}/initramfs-tools/hooks/expand-tools"
     fi
-	
-	if [ "$ENABLE_DHCP" = false ] ; then
-      # Get cdir from NET_ADDRESS e.g. 24
-      cdir=$(${NET_ADDRESS} | cut -d '/' -f2)
+    
+    # Replace fstab root partition with encrypted partition mapping
+    sed -i "s/mmcblk0p2/mapper\/${CRYPTFS_MAPPING}/" "${ETC_DIR}/fstab"
 
-      # Convert cdir ro netmask e.g. 24 to 255.255.255.0
-      NET_MASK=$(cdr2mask "$cdir")
+    # Add encrypted partition to crypttab and fstab
+    install_readonly files/mount/crypttab "${ETC_DIR}/crypttab"
+    echo "${CRYPTFS_MAPPING} /dev/mmcblk0p2 none luks,initramfs" >> "${ETC_DIR}/crypttab"
 	
-	  # Write static ip settings to "${ETC_DIR}"/initramfs-tools/initramfs.conf
-      sed -i "\$aIP=${NET_ADDRESS}::${NET_GATEWAY}:${NET_MASK}:${HOSTNAME}:" "${ETC_DIR}"/initramfs-tools/initramfs.conf
-
-	  # Regenerate initramfs
-	  chroot_exec mkinitramfs -o "/boot/firmware/initramfs-${KERNEL_VERSION}" "${KERNEL_VERSION}"
+	if [ "$ENABLE_USBBOOT" = true ] && [ "$ENABLE_SPLITFS" = false ]; then
+	  sed -i "s/mmcblk0p1/sda1/" "${ETC_DIR}/fstab"
+      # Add usb/sda2 disk to crypttab
+      sed -i "s/mmcblk0p2/sda2/" "${ETC_DIR}/crypttab"
+    fi
+    
+    # Add encrypted root partition to fstab and crypttab
+    if [ "$ENABLE_SPLITFS" = true ] && [ "$ENABLE_USBBOOT" = false ]; then
+      # Add usb/sda1 disk to crypttab
+      sed -i "s/mmcblk0p2/sda1/" "${ETC_DIR}/crypttab"
     fi
 
-	if [ "$CRYPTFS_DROPBEAR" = true ]; then
-	  if [ -n "$CRYPTFS_DROPBEAR_PUBKEY" ] && [ -f "$CRYPTFS_DROPBEAR_PUBKEY" ] ; then
- 	    install_readonly "${CRYPTFS_DROPBEAR_PUBKEY}" "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
- 	    cat "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub >> "${ETC_DIR}"/dropbear-initramfs/authorized_keys
- 	  else
- 	    # Create key
- 	    chroot_exec /usr/bin/dropbearkey -t rsa -f /etc/dropbear-initramfs/id_rsa.dropbear
+    if [ "$CRYPTFS_DROPBEAR" = true ]; then
+      if [ "$ENABLE_DHCP" = false ] ; then
+        # Get cdir from NET_ADDRESS e.g. 24
+        cdir=$(printf "%s" "${NET_ADDRESS}" | cut -d '/' -f2)
 
- 	    # Convert dropbear key to openssh key
- 	    chroot_exec /usr/lib/dropbear/dropbearconvert dropbear openssh /etc/dropbear-initramfs/id_rsa.dropbear /etc/dropbear-initramfs/id_rsa
+        # Convert cdir ro netmask e.g. 24 to 255.255.255.0
+        NET_MASK=$(cdr2mask "$cdir")
+	
+        # Write static ip settings to "${ETC_DIR}"/initramfs-tools/initramfs.conf
+        # ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>
+        sed -i "\$a\nIP=${NET_ADDRESS}::${NET_GATEWAY}:${NET_MASK}:${HOSTNAME}:" "${ETC_DIR}"/initramfs-tools/initramfs.conf
+      else
+        sed -i "\$a\nIP=::::${HOSTNAME}::dhcp" "${ETC_DIR}"/initramfs-tools/initramfs.conf
+      fi
+    
+      if [ -n "$CRYPTFS_DROPBEAR_PUBKEY" ] && [ -f "$CRYPTFS_DROPBEAR_PUBKEY" ] ; then
+        install_readonly "${CRYPTFS_DROPBEAR_PUBKEY}" "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
+        cat "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub >> "${ETC_DIR}"/dropbear-initramfs/authorized_keys
+      else
+        # Create key
+        chroot_exec /usr/bin/dropbearkey -t rsa -f /etc/dropbear-initramfs/id_rsa.dropbear
 
- 	    # Get Public Key Part
- 	    chroot_exec /usr/bin/dropbearkey -y -f /etc/dropbear-initramfs/id_rsa.dropbear | chroot_exec tee /etc/dropbear-initramfs/id_rsa.pub
+        # Convert dropbear key to openssh key
+        chroot_exec /usr/lib/dropbear/dropbearconvert dropbear openssh /etc/dropbear-initramfs/id_rsa.dropbear /etc/dropbear-initramfs/id_rsa
 
- 	    # Delete unwanted lines
- 	    sed -i '/Public/d' "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
- 	    sed -i '/Fingerprint/d' "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
+        # Get Public Key Part
+        chroot_exec /usr/bin/dropbearkey -y -f /etc/dropbear-initramfs/id_rsa.dropbear | chroot_exec tee /etc/dropbear-initramfs/id_rsa.pub
 
- 	    # Trust the new key
- 	    cat "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub > "${ETC_DIR}"/dropbear-initramfs/authorized_keys
+        # Delete unwanted lines
+        sed -i '/Public/d' "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
+        sed -i '/Fingerprint/d' "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub
 
- 	    # Save Keys - convert with putty from rsa/openssh to puttkey
- 	    cp -f "${ETC_DIR}"/dropbear-initramfs/id_rsa "${BASEDIR}"/dropbear_initramfs_key.rsa
+        # Trust the new key
+        cat "${ETC_DIR}"/dropbear-initramfs/id_rsa.pub > "${ETC_DIR}"/dropbear-initramfs/authorized_keys
 
- 	    # Get unlock script
- 	    install_exec files/initramfs/crypt_unlock.sh "${ETC_DIR}"/initramfs-tools/hooks/crypt_unlock.sh
+        # Save Keys - convert with putty from rsa/openssh to puttkey
+        cp -f "${ETC_DIR}"/dropbear-initramfs/id_rsa "${BASEDIR}"/dropbear_initramfs_key.rsa
 
- 	    # Enable Dropbear inside initramfs
- 	    printf "#\n# DROPBEAR: [ y | n ]\n#\n\nDROPBEAR=y\n" >> "${ETC_DIR}/initramfs-tools/initramfs.conf"
+        # Get unlock script
+        install_exec files/initramfs/crypt_unlock.sh "${ETC_DIR}"/initramfs-tools/hooks/crypt_unlock.sh
 
- 	    # Enable Dropbear inside initramfs
- 	    sed -i "54 i sleep 5" "${R}"/usr/share/initramfs-tools/scripts/init-premount/dropbear	  
-	  fi
-	else
-	  # Disable SSHD inside initramfs
-	  printf "#\n# DROPBEAR: [ y | n ]\n#\n\nDROPBEAR=n\n" >> "${ETC_DIR}/initramfs-tools/initramfs.conf"
-	fi
+        # Enable Dropbear inside initramfs
+        printf "#\n# DROPBEAR: [ y | n ]\n#\n\nDROPBEAR=y\n" >> "${ETC_DIR}/initramfs-tools/initramfs.conf"
+
+        # Enable Dropbear inside initramfs
+        sed -i "54 i sleep 5" "${R}"/usr/share/initramfs-tools/scripts/init-premount/dropbear	  
+      fi
+    # CRYPTFSDROPBEAR=false
+    else
+      # Disable SSHD inside initramfs
+      printf "#\n# DROPBEAR: [ y | n ]\n#\n\nDROPBEAR=n\n" >> "${ETC_DIR}/initramfs-tools/initramfs.conf"
+    fi
 
     # Add cryptsetup modules to initramfs
-    printf "#\n# CRYPTSETUP: [ y | n ]\n#\n\nCRYPTSETUP=y\n" >> "${ETC_DIR}/initramfs-tools/conf-hook"
+    #printf "#\n# CRYPTSETUP: [ y | n ]\n#\n\nCRYPTSETUP=y\n" >> "${ETC_DIR}/initramfs-tools/conf-hook"
 
     # Dummy mapping required by mkinitramfs
-    echo "0 1 crypt $(echo "${CRYPTFS_CIPHER}" | cut -d ':' -f 1) ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff 0 7:0 4096" | chroot_exec dmsetup create "${CRYPTFS_MAPPING}"
+    echo "0 1 crypt "${CRYPTFS_CIPHER}" ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff 0 7:0 4096" | chroot_exec dmsetup create "${CRYPTFS_MAPPING}"
 
     # Generate initramfs with encrypted root partition support
     chroot_exec mkinitramfs -o "/boot/firmware/initramfs-${KERNEL_VERSION}" "${KERNEL_VERSION}"
 
     # Remove dummy mapping
     chroot_exec cryptsetup close "${CRYPTFS_MAPPING}"
+  # CRYPTFS=false
   else
+  	#USB BOOT /boot on sda1 / on sda2
+	if [ "$ENABLE_USBBOOT" = true ] ; then
+  	  sed -i "s/mmcblk0p1/sda1/" "${ETC_DIR}/fstab"
+  	  sed -i "s/mmcblk0p2/sda2/" "${ETC_DIR}/fstab"
+	fi
+
+	# Add usb/sda disk root partition to fstab
+	if [ "$ENABLE_SPLITFS" = true ] ; then
+  	  sed -i "s/mmcblk0p2/sda1/" "${ETC_DIR}/fstab"
+	fi
     # Generate initramfs without encrypted root partition support
     chroot_exec mkinitramfs -o "/boot/firmware/initramfs-${KERNEL_VERSION}" "${KERNEL_VERSION}"
   fi

--- a/bootstrap.d/15-rpi-config.sh
+++ b/bootstrap.d/15-rpi-config.sh
@@ -112,7 +112,7 @@ if [ "$ENABLE_TURBO" = true ] ; then
   echo "boot_delay=1" >> "${BOOT_DIR}/config.txt"
 fi
 
-if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
+if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] || [ "$RPI_MODEL" = 4 ]; then
 
   # Bluetooth enabled
   if [ "$ENABLE_BLUETOOTH" = true ] ; then
@@ -125,12 +125,12 @@ if [ "$RPI_MODEL" = 0 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] ; then
     # Copy downloaded sources
     mv "${temp_dir}/pi-bluetooth" "${R}/tmp/"
 
-    # Bluetooth firmware from arch aur https://aur.archlinux.org/packages/pi-bluetooth/
-    as_nobody wget -q -O "${R}/tmp/pi-bluetooth/LICENCE.broadcom_bcm43xx" https://aur.archlinux.org/cgit/aur.git/plain/LICENCE.broadcom_bcm43xx?h=pi-bluetooth
-    as_nobody wget -q -O "${R}/tmp/pi-bluetooth/BCM43430A1.hcd" https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM43430A1.hcd
-
     # Set permissions
     chown -R root:root "${R}/tmp/pi-bluetooth"
+    
+    # Bluetooth firmware from arch aur https://aur.archlinux.org/packages/pi-bluetooth/
+    wget -q -O "${R}/tmp/pi-bluetooth/LICENCE.broadcom_bcm43xx" https://aur.archlinux.org/cgit/aur.git/plain/LICENCE.broadcom_bcm43xx?h=pi-bluetooth
+    wget -q -O "${R}/tmp/pi-bluetooth/BCM43430A1.hcd" https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM43430A1.hcd
 
     # Install tools
     install_readonly "${R}/tmp/pi-bluetooth/usr/bin/btuart" "${R}/usr/bin/btuart"
@@ -210,7 +210,11 @@ if [ "$ENABLE_SYSTEMDSWAP" = true ] ; then
 
   # Change into downloaded src dir
   cd "${R}/tmp/systemd-swap" || exit
-
+  
+  # Get Verion
+  VERSION=$(git tag | tail -n 1)
+  #sed -i "s/DEB_NAME=.*/DEB_NAME=systemd-swap_all/g" "${R}/tmp/systemd-swap/package.sh"
+  
   # Build package
   bash ./package.sh debian
   
@@ -221,7 +225,7 @@ if [ "$ENABLE_SYSTEMDSWAP" = true ] ; then
   chown -R root:root "${R}/tmp/systemd-swap"
 
   # Install package - IMPROVE AND MAKE IT POSSIBLE WITHOUT VERSION NR.
-  chroot_exec dpkg -i /tmp/systemd-swap/systemd-swap_4.0.1_any.deb
+  chroot_exec dpkg -i /tmp/systemd-swap/systemd-swap_"$VERSION"_all.deb
 
   # Enable service
   chroot_exec systemctl enable systemd-swap

--- a/bootstrap.d/20-networking.sh
+++ b/bootstrap.d/20-networking.sh
@@ -106,7 +106,7 @@ if [ "$ENABLE_WIRELESS" = true ] ; then
   temp_dir=$(as_nobody mktemp -d)
 
   # Fetch firmware binary blob for RPI3B+
-  if [ "$RPI_MODEL" = 3P ] ; then
+  if [ "$RPI_MODEL" = 3P ] || [ "$RPI_MODEL" = 4 ] ; then
     # Fetch firmware binary blob for RPi3P
     as_nobody wget -q -O "${temp_dir}/brcmfmac43455-sdio.bin" "${WLAN_FIRMWARE_URL}/brcmfmac43455-sdio.bin"
     as_nobody wget -q -O "${temp_dir}/brcmfmac43455-sdio.txt" "${WLAN_FIRMWARE_URL}/brcmfmac43455-sdio.txt"

--- a/bootstrap.d/43-videocore.sh
+++ b/bootstrap.d/43-videocore.sh
@@ -34,11 +34,11 @@ if [ "$ENABLE_VIDEOCORE" = true ] ; then
   cd "${R}"/tmp/userland/build
 
   if [ "$RELEASE_ARCH" = "arm64" ] ; then
-  cmake -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_BUILD_TYPE=release -DARM64=ON -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_ASM_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -U_FORTIFY_SOURCE" -DCMAKE_ASM_FLAGS="${CMAKE_ASM_FLAGS} -c" -DVIDEOCORE_BUILD_DIR="${R}" "${R}/tmp/userland"
+  cmake -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_BUILD_TYPE=release -DCMAKE_TOOLCHAIN_FILE="${R}"/tmp/userland/makefiles/cmake/toolchains/aarch64-linux-gnu.cmake -DARM64=ON -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DCMAKE_ASM_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -U_FORTIFY_SOURCE" -DCMAKE_ASM_FLAGS="${CMAKE_ASM_FLAGS} -c" -DVIDEOCORE_BUILD_DIR="${R}" "${R}/tmp/userland"
   fi
 
   if [ "$RELEASE_ARCH" = "armel" ] ; then
-  cmake -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_BUILD_TYPE=release -DCMAKE_C_COMPILER=arm-linux-gnueabi-gcc -DCMAKE_CXX_COMPILER=arm-linux-gnueabi-g++ -DCMAKE_ASM_COMPILER=arm-linux-gnueabi-gcc -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -U_FORTIFY_SOURCE" -DCMAKE_ASM_FLAGS="${CMAKE_ASM_FLAGS} -c" -DCMAKE_SYSTEM_PROCESSOR="arm" -DVIDEOCORE_BUILD_DIR="${R}" "${R}/tmp/userland"
+  cmake -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_BUILD_TYPE=release -DCMAKE_TOOLCHAIN_FILE="${R}"/tmp/userland/makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake -DCMAKE_C_COMPILER=arm-linux-gnueabi-gcc -DCMAKE_CXX_COMPILER=arm-linux-gnueabi-g++ -DCMAKE_ASM_COMPILER=arm-linux-gnueabi-gcc -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -U_FORTIFY_SOURCE" -DCMAKE_ASM_FLAGS="${CMAKE_ASM_FLAGS} -c" -DCMAKE_SYSTEM_PROCESSOR="arm" -DVIDEOCORE_BUILD_DIR="${R}" "${R}/tmp/userland"
   fi
 
   if [ "$RELEASE_ARCH" = "armhf" ] ; then

--- a/bootstrap.d/44-nexmon_monitor_patch.sh
+++ b/bootstrap.d/44-nexmon_monitor_patch.sh
@@ -74,7 +74,7 @@ if [ "$ENABLE_NEXMON" = true ] && [ "$ENABLE_WIRELESS" = true ]; then
     cp -f "${NEXMON_ROOT}"/patches/bcm43430a1/7_45_41_46/nexmon/brcmfmac43430-sdio.bin "${WLAN_FIRMWARE_DIR}"/brcmfmac43430-sdio.bin
   fi
   
-  if [ "$RPI_MODEL" = 3P ] ; then
+  if [ "$RPI_MODEL" = 3P ] || [ "$RPI_MODEL" = 4 ] ; then
     cd "${NEXMON_ROOT}"/patches/bcm43455c0/7_45_154/nexmon || exit
 	sed -i -e 's/all:.*/all: $(RAM_FILE)/g' ${NEXMON_ROOT}/patches/bcm43455c0/7_45_154/nexmon/Makefile
     make clean

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -198,6 +198,10 @@ KERNEL_BPF=${KERNEL_BPF:=false}
 KERNEL_DEFAULT_GOV=${KERNEL_DEFAULT_GOV:=ondemand}
 KERNEL_SECURITY=${KERNEL_SECURITY:=false}
 KERNEL_NF=${KERNEL_NF:=false}
+KERNEL_DHKEY=${KERNEL_DHKEY:=true}
+KERNEL_BTRFS=${KERNEL_BTRFS:=false}
+KERNEL_NSPAN=${KERNEL_NSPAN:=false}
+KERNEL_POEHAT=${KERNEL_POEHAT:=false}
 
 # Kernel compilation from source directory settings
 KERNELSRC_DIR=${KERNELSRC_DIR:=""}
@@ -219,7 +223,8 @@ REDUCE_LOCALE=${REDUCE_LOCALE:=true}
 ENABLE_CRYPTFS=${ENABLE_CRYPTFS:=false}
 CRYPTFS_PASSWORD=${CRYPTFS_PASSWORD:=""}
 CRYPTFS_MAPPING=${CRYPTFS_MAPPING:="secure"}
-CRYPTFS_CIPHER=${CRYPTFS_CIPHER:="aes-xts-plain64:sha512"}
+CRYPTFS_CIPHER=${CRYPTFS_CIPHER:="aes-xts-plain64"}
+CRYPTFS_HASH=${CRYPTFS_HASH:="sha512"}
 CRYPTFS_XTSKEYSIZE=${CRYPTFS_XTSKEYSIZE:=512}
 #Dropbear-initramfs supports unlocking encrypted filesystem via SSH on bootup
 CRYPTFS_DROPBEAR=${CRYPTFS_DROPBEAR:=false}
@@ -410,7 +415,7 @@ fi
 # Add cryptsetup package to enable filesystem encryption
 if [ "$ENABLE_CRYPTFS" = true ]  && [ "$BUILD_KERNEL" = true ] ; then
   REQUIRED_PACKAGES="${REQUIRED_PACKAGES} cryptsetup"
-  APT_INCLUDES="${APT_INCLUDES},cryptsetup,busybox,console-setup"
+  APT_INCLUDES="${APT_INCLUDES},cryptsetup,busybox,console-setup,cryptsetup-initramfs"
 
   # If cryptfs,dropbear and initramfs are enabled include dropbear-initramfs package
   if [ "$CRYPTFS_DROPBEAR" = true ] && [ "$ENABLE_INITRAMFS" = true ]; then
@@ -831,7 +836,7 @@ if [ "$ENABLE_CRYPTFS" = true ] ; then
   echo -n ${CRYPTFS_PASSWORD} > .password
 
   # Initialize encrypted partition
-  echo "YES" | cryptsetup luksFormat "${ROOT_LOOP}" -c "${CRYPTFS_CIPHER}" -s "${CRYPTFS_XTSKEYSIZE}" .password
+  cryptsetup --verbose --debug -q luksFormat "${ROOT_LOOP}" -c "${CRYPTFS_CIPHER}" -h "${CRYPTFS_HASH}" -s "${CRYPTFS_XTSKEYSIZE}" .password
 
   # Open encrypted partition and setup mapping
   cryptsetup luksOpen "${ROOT_LOOP}" -d .password "${CRYPTFS_MAPPING}"

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -44,6 +44,9 @@ RPI_MODEL=${RPI_MODEL:=2}
 
 # Debian release
 RELEASE=${RELEASE:=buster}
+if [ $RELEASE = "bullseye" ] ; then
+ RELEASE=testing
+fi
 
 # Kernel Branch
 KERNEL_BRANCH=${KERNEL_BRANCH:=""}
@@ -52,7 +55,6 @@ KERNEL_BRANCH=${KERNEL_BRANCH:=""}
 KERNEL_URL=${KERNEL_URL:=https://github.com/raspberrypi/linux}
 FIRMWARE_URL=${FIRMWARE_URL:=https://github.com/raspberrypi/firmware/raw/master/boot}
 WLAN_FIRMWARE_URL=${WLAN_FIRMWARE_URL:=https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm}
-COLLABORA_URL=${COLLABORA_URL:=https://repositories.collabora.co.uk/debian}
 FBTURBO_URL=${FBTURBO_URL:=https://github.com/ssvb/xf86-video-fbturbo.git}
 UBOOT_URL=${UBOOT_URL:=https://git.denx.de/u-boot.git}
 VIDEOCORE_URL=${VIDEOCORE_URL:=https://github.com/raspberrypi/userland}

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -64,11 +64,16 @@ SYSTEMDSWAP_URL=${SYSTEMDSWAP_URL:=https://github.com/Nefelim4ag/systemd-swap.gi
 RPI_32_KERNEL_URL=${RPI_32_KERNEL_URL:=https://github.com/hypriot/rpi-kernel/releases/download/v4.14.34/raspberrypi-kernel_20180422-141901_armhf.deb}
 RPI_32_KERNELHEADER_URL=${RPI_32_KERNELHEADER_URL:=https://github.com/hypriot/rpi-kernel/releases/download/v4.14.34/raspberrypi-kernel-headers_20180422-141901_armhf.deb}
 # Kernel has KVM and zswap enabled - use if KERNEL_* parameters and precompiled kernel are used 
-RPI3_64_BIS_KERNEL_URL=${RPI3_64_BIS_KERNEL_URL:=https://github.com/sakaki-/bcmrpi3-kernel-bis/releases/download/4.14.80.20181113/bcmrpi3-kernel-bis-4.14.80.20181113.tar.xz}
+RPI3_64_BIS_KERNEL_URL=${RPI3_64_BIS_KERNEL_URL:=https://github.com/sakaki-/bcmrpi3-kernel-bis/releases/download/4.19.80.20191022/bcmrpi3-kernel-bis-4.19.80.20191022.tar.xz}
 # Default precompiled 64bit kernel
-RPI3_64_DEF_KERNEL_URL=${RPI3_64_DEF_KERNEL_URL:=https://github.com/sakaki-/bcmrpi3-kernel/releases/download/4.14.80.20181113/bcmrpi3-kernel-4.14.80.20181113.tar.xz}
+RPI3_64_DEF_KERNEL_URL=${RPI3_64_DEF_KERNEL_URL:=https://github.com/sakaki-/bcmrpi3-kernel/releases/download/4.19.80.20191022/bcmrpi3-kernel-4.19.80.20191022.tar.xz}
+# Sakaki BIS Kernel RPI4 - https://github.com/sakaki-/bcm2711-kernel-bis
+RPI4_64_BIS_KERNEL_URL=${RPI4_64_BIS_KERNEL_URL:=https://github.com/sakaki-/bcm2711-kernel-bis/releases/download/4.19.59.20190724/bcm2711-kernel-bis-4.19.59.20190724.tar.xz}
+# Default precompiled 64bit kernel - https://github.com/sakaki-/bcm2711-kernel
+RPI4_64_DEF_KERNEL_URL=${RPI4_64_DEF_KERNEL_URL:=https://github.com/sakaki-/bcm2711-kernel-bis/releases/download/4.19.59.20190724/bcm2711-kernel-bis-4.19.59.20190724.tar.xz}
 # Generic 
 RPI3_64_KERNEL_URL=${RPI3_64_KERNEL_URL:=$RPI3_64_DEF_KERNEL_URL}
+RPI4_64_KERNEL_URL=${RPI4_64_KERNEL_URL:=$RPI4_64_DEF_KERNEL_URL}
 # Kali kernel src - used if ENABLE_NEXMON=true (they patch the wlan kernel modul)
 KALI_KERNEL_URL=${KALI_KERNEL_URL:=https://github.com/Re4son/re4son-raspberrypi-linux.git}
 
@@ -224,7 +229,7 @@ CHROOT_SCRIPTS=${CHROOT_SCRIPTS:=""}
 
 # Packages required in the chroot build environment
 APT_INCLUDES=${APT_INCLUDES:=""}
-APT_INCLUDES="${APT_INCLUDES},apt-transport-https,apt-utils,ca-certificates,debian-archive-keyring,dialog,sudo,systemd,sysvinit-utils,locales,keyboard-configuration,console-setup,libnss-systemd"
+APT_INCLUDES="${APT_INCLUDES},flex,bison,libssl-dev,apt-transport-https,apt-utils,ca-certificates,debian-archive-keyring,dialog,sudo,systemd,sysvinit-utils,locales,keyboard-configuration,console-setup,libnss-systemd"
 
 # Packages to exclude from chroot build environment
 APT_EXCLUDES=${APT_EXCLUDES:=""}
@@ -289,13 +294,15 @@ if [ -n "$SET_ARCH" ] ; then
     if [ "$RPI_MODEL" = 2 ] || [ "$RPI_MODEL" = 3 ] || [ "$RPI_MODEL" = 3P ] || [ "$RPI_MODEL" = 4 ] ; then
       if [ "$RPI_MODEL" != 4 ] ; then
         KERNEL_DEFCONFIG=${KERNEL_DEFCONFIG:=bcm2709_defconfig}
+		KERNEL_IMAGE=${KERNEL_IMAGE:=kernel7.img}
       else
         KERNEL_DEFCONFIG=${KERNEL_DEFCONFIG:=bcm2711_defconfig}
+		KERNEL_IMAGE=${KERNEL_IMAGE:=kernel7l.img}
       fi
       
       REQUIRED_PACKAGES="${REQUIRED_PACKAGES} crossbuild-essential-armhf"
       RELEASE_ARCH=${RELEASE_ARCH:=armhf}
-      KERNEL_IMAGE=${KERNEL_IMAGE:=kernel7.img}
+      
       CROSS_COMPILE=${CROSS_COMPILE:=arm-linux-gnueabihf-}
     fi
   fi
@@ -385,7 +392,7 @@ fi
 
 # Add deps for nexmon
 if [ "$ENABLE_NEXMON" = true ] ; then
-  REQUIRED_PACKAGES="${REQUIRED_PACKAGES} libgmp3-dev gawk qpdf bison flex make autoconf automake build-essential libtool"
+  REQUIRED_PACKAGES="${REQUIRED_PACKAGES} libgmp3-dev gawk qpdf make autoconf automake build-essential libtool"
 fi
 
 # Add libncurses5 to enable kernel menuconfig
@@ -470,7 +477,7 @@ if [ -n "$MISSING_PACKAGES" ] ; then
   [ "$confirm" != "y" ] && exit 1
 
   # Make sure all missing required packages are installed
-  apt-get -qq -y install `echo "${MISSING_PACKAGES}" | sed "s/ //"`
+  apt-get update && apt-get -qq -y install `echo "${MISSING_PACKAGES}" | sed "s/ //"`
 fi
 
 # Check if ./bootstrap.d directory exists


### PR DESCRIPTION
RPI4
Debian Bullseye
Added and removed kernel options 
QEMU with 64bit kernel doenst fail anymore (didnt boot it up, but it compiled)
No more compile error on bluetooth firmware download
Kernel bump from 4.14 to 4.19
flex,bison and libssl-dev required to build kernel

https://github.com/drtyhlpr/rpi23-gen-image/issues/203
https://github.com/drtyhlpr/rpi23-gen-image/issues/196
copying vexpress arm32 version to arm64 works just fine
`/root/rpi23-gen-image/images/bullseye/qemu/2019-10-22-arm64-CURRENT-rpi3P-bullseye-arm64.qcow2 (16G) : successfully created`
