### PR TITLE
fixup4*  and start4* files missing for Pi4 boot

### DIFF
--- a/bootstrap.d/15-rpi-config.sh
+++ b/bootstrap.d/15-rpi-config.sh
@@ -14,6 +14,14 @@ if [ -n "$RPI_FIRMWARE_DIR" ] && [ -d "$RPI_FIRMWARE_DIR" ] ; then
   cp "${RPI_FIRMWARE_DIR}"/boot/start.elf "${BOOT_DIR}"/start.elf
   cp "${RPI_FIRMWARE_DIR}"/boot/start_cd.elf "${BOOT_DIR}"/start_cd.elf
   cp "${RPI_FIRMWARE_DIR}"/boot/start_x.elf "${BOOT_DIR}"/start_x.elf
+  cp "${RPI_FIRMWARE_DIR}"/boot/fixup4cd.dat "${BOOT_DIR}"/fixup4cd.dat
+  cp "${RPI_FIRMWARE_DIR}"/boot/fixup4.dat "${BOOT_DIR}"/fixup4.dat
+  cp "${RPI_FIRMWARE_DIR}"/boot/fixup4db.dat "${BOOT_DIR}"/fixup4db.dat
+  cp "${RPI_FIRMWARE_DIR}"/boot/fixup4x.dat "${BOOT_DIR}"/fixup4x.dat
+  cp "${RPI_FIRMWARE_DIR}"/boot/start4cd.elf "${BOOT_DIR}"/start4cd.elf
+  cp "${RPI_FIRMWARE_DIR}"/boot/start4db.elf "${BOOT_DIR}"/start4db.elf
+  cp "${RPI_FIRMWARE_DIR}"/boot/start4.elf "${BOOT_DIR}"/start4x.elf
+  cp "${RPI_FIRMWARE_DIR}"/boot/start4x.elf "${BOOT_DIR}"/start4x.elf
 else
   # Create temporary directory for boot binaries
   temp_dir=$(as_nobody mktemp -d)
@@ -26,6 +34,14 @@ else
   as_nobody wget -q -O "${temp_dir}/start.elf" "${FIRMWARE_URL}/start.elf"
   as_nobody wget -q -O "${temp_dir}/start_cd.elf" "${FIRMWARE_URL}/start_cd.elf"
   as_nobody wget -q -O "${temp_dir}/start_x.elf" "${FIRMWARE_URL}/start_x.elf"
+  as_nobody wget -q -O "${temp_dir}/fixup4cd.dat" "${FIRMWARE_URL}/fixup4cd.dat"
+  as_nobody wget -q -O "${temp_dir}/fixup4.dat" "${FIRMWARE_URL}/fixup4.dat"
+  as_nobody wget -q -O "${temp_dir}/fixup4db.dat" "${FIRMWARE_URL}/fixup4db.dat"
+  as_nobody wget -q -O "${temp_dir}/fixup4x.dat" "${FIRMWARE_URL}/fixup4x.dat"
+  as_nobody wget -q -O "${temp_dir}/start4cd.elf" "${FIRMWARE_URL}/start4cd.elf"
+  as_nobody wget -q -O "${temp_dir}/start4db.elf" "${FIRMWARE_URL}/start4db.elf"
+  as_nobody wget -q -O "${temp_dir}/start4x.elf" "${FIRMWARE_URL}/start4x.elf"
+  as_nobody wget -q -O "${temp_dir}/start4x.elf" "${FIRMWARE_URL}/start4x.elf"
 
   # Move downloaded boot binaries
   mv "${temp_dir}/"* "${BOOT_DIR}/"

--- a/bootstrap.d/15-rpi-config.sh
+++ b/bootstrap.d/15-rpi-config.sh
@@ -1,5 +1,5 @@
 #
-# Setup RPi2/3 config and cmdline
+# Setup RPi2/3/4 config and cmdline
 #
 
 # Load utility functions

--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -36,7 +36,7 @@ fi
 
 # Introduce settings
 set -e
-echo -n -e "\n#\n# RPi 0/1/2/3 Bootstrap Settings\n#\n"
+echo -n -e "\n#\n# RPi 0/1/2/3/4 Bootstrap Settings\n#\n"
 set -x
 
 # Raspberry Pi model configuration


### PR DESCRIPTION
Proposal to add copy of fixup4*  and start4* files from firmware repository 
into boot folder of the new image.

If these files are not present boot hangs at early stage.
Tested with buster and bullseye 64