### PR TITLE
removed deprecated mkknlimg and mote to buster/bullseye

### DIFF
--- a/bootstrap.d/11-apt.sh
+++ b/bootstrap.d/11-apt.sh
@@ -19,13 +19,13 @@ sed -i "s/\/ftp.debian.org\//\/${APT_SERVER}\//" "${ETC_DIR}/apt/sources.list"
 
 #Fix for changing path for security updates in testing/bullseye
 if [ "$RELEASE" = "testing" ] ; then
-sed -i "s,stretch\\/updates,testing-security," "${ETC_DIR}/apt/sources.list"
-sed -i "s/ stretch/ ${RELEASE}/" "${ETC_DIR}/apt/sources.list"
+sed -i "s,buster\\/updates,testing-security," "${ETC_DIR}/apt/sources.list"
+sed -i "s/ buster/ ${RELEASE}/" "${ETC_DIR}/apt/sources.list"
 fi
 
 if [ -z "$RELEASE" ] ; then
 # Change release in sources list
-sed -i "s/ stretch/ ${RELEASE}/" "${ETC_DIR}/apt/sources.list"
+sed -i "s/ buster/ ${RELEASE}/" "${ETC_DIR}/apt/sources.list"
 fi
 
 # Upgrade package index and update all installed packages and changed dependencies

--- a/bootstrap.d/13-kernel.sh
+++ b/bootstrap.d/13-kernel.sh
@@ -1,5 +1,5 @@
 #
-# Build and Setup RPi2/3 Kernel
+# Build and Setup RPi2/3/4 Kernel 4.XX 5.XX
 #
 
 # Load utility functions
@@ -780,7 +780,7 @@ if [ "$BUILD_KERNEL" = true ] ; then
 
   if [ "$ENABLE_UBOOT" = false ] ; then
     # Convert and copy kernel image to the boot directory
-    "${KERNEL_DIR}/scripts/mkknlimg" "${KERNEL_DIR}/arch/${KERNEL_ARCH}/boot/${KERNEL_BIN_IMAGE}" "${BOOT_DIR}/${KERNEL_IMAGE}"
+    cp "${KERNEL_DIR}/arch/${KERNEL_ARCH}/boot/${KERNEL_BIN_IMAGE}" "${BOOT_DIR}/${KERNEL_IMAGE}"
   else
     # Copy kernel image to the boot directory
     install_readonly "${KERNEL_DIR}/arch/${KERNEL_ARCH}/boot/${KERNEL_BIN_IMAGE}" "${BOOT_DIR}/${KERNEL_IMAGE}"

--- a/files/apt/sources.list
+++ b/files/apt/sources.list
@@ -1,8 +1,8 @@
-deb http://ftp.debian.org/debian stretch main contrib
-#deb-src http://ftp.debian.org/debian stretch main contrib
+deb http://ftp.debian.org/debian buster main contrib
+#deb-src http://ftp.debian.org/debian buster main contrib
 
-deb http://ftp.debian.org/debian/ stretch-updates main contrib
-#deb-src http://ftp.debian.org/debian/ stretch-updates main contrib
+deb http://ftp.debian.org/debian/ buster-updates main contrib
+#deb-src http://ftp.debian.org/debian/ buster-updates main contrib
 
-deb http://security.debian.org/ stretch/updates main contrib
-#deb-src http://security.debian.org/ stretch/updates main contrib
+deb http://security.debian.org/ buster/updates main contrib
+#deb-src http://security.debian.org/ buster/updates main contrib


### PR DESCRIPTION
Removed deprecated mkknlimg see [kernel issue #3249](https://github.com/raspberrypi/linux/issues/3249)
change stretch to buster as stable
change buster to bullseye as testing

Signed-off-by: Gérard Vidal <gerard.vidal@ens-lyon.fr>